### PR TITLE
Add instructions for upgrading to Dart 2 from Dart 1

### DIFF
--- a/src/tools/sdk/_mac.md
+++ b/src/tools/sdk/_mac.md
@@ -11,8 +11,35 @@ To install a **dev channel** release use `--devel`:
 $ brew install dart --devel
 ```
 
-To **upgrade** when a new release of Dart is available run:
+### Upgrade
+
+To upgrade when a new release of Dart is available run:
 
 ```terminal
 $ brew upgrade dart
 ```
+
+To upgrade to a dev channel release when a stable release is currently active run:
+
+```terminal
+$ brew upgrade dart --devel --force
+```
+
+### Switch release
+
+To switch between locally installed dart releases run
+`brew switch dart <version>`. Examples:
+
+```terminal
+$ brew switch dart 1.24.3
+$ brew switch dart 2.0.0-dev.64.1
+```
+
+If you aren't sure which versions of dart you have installed, then run:
+
+```terminal
+$ brew info dart
+```
+
+The command output includes the latest stable and dev versions at the top, and
+your locally installed versions are listed after that.


### PR DESCRIPTION
Folks have been having problems upgrading to Dart 2 from Dart 1. For example, see this SO question: https://stackoverflow.com/q/50928834/3046255

On macOS, you need an extra flag to be able to upgrade from Dart 1 to Dart 2 using brew. This PR updates the instructions accordingly.

Staged at https://dartlang-org-staging-0.firebaseapp.com/tools/sdk#install

(If you agree with this change, I'll submit a followup PR to tweak the webdev _Get Started_ instructions -- in addition to propagating the SDK install instructions themselves.)

cc @kevmoo 


