### PR TITLE
prettify.rb unindent: handle code less indented than filter tags

### DIFF
--- a/src/_plugins/prettify.rb
+++ b/src/_plugins/prettify.rb
@@ -107,7 +107,7 @@ module Prettify
       # Only trim the excess relative to min_len
       len = len < min_len ? min_len : len - min_len
 
-      len == 0 ? code : lines.map{|s| s.length < len ? s : s[len..-1]}.join("\n")
+      len == 0 ? code : lines.map{|s| s.length < len ? s : s.sub(/^[ \t]{#{len}}/, '')}.join("\n")
     end
   end
 end


### PR DESCRIPTION
I double checked that this fix leaves site-www unchanged (modulo whitespace -- see local log www.g-run-log-180717-8.txt)