### PR TITLE
Update SDK installation instructions to emphasize dev channel

### DIFF
--- a/src/tools/sdk/_linux.md
+++ b/src/tools/sdk/_linux.md
@@ -26,11 +26,7 @@ $ sudo sh -c 'curl https://storage.googleapis.com/download.dartlang.org/linux/de
 {% endif %}
 
 Then install the
-{% if site.data.pkg-vers.SDK.channel == 'dev' -%}
-**dev**
-{% else -%}
-**stable**
-{% endif -%}
+**{{site.data.pkg-vers.SDK.channel}}**
 release of the Dart SDK:
 
 ```terminal

--- a/src/tools/sdk/_linux.md
+++ b/src/tools/sdk/_linux.md
@@ -9,28 +9,58 @@ versions are released.
 
 Perform the following **one-time setup**:
 
+{% if site.data.pkg-vers.SDK.channel == 'dev' %}
+```terminal
+$ sudo apt-get update
+$ sudo apt-get install apt-transport-https
+$ sudo sh -c 'curl https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -'
+$ sudo sh -c 'curl https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_unstable.list > /etc/apt/sources.list.d/dart_unstable.list'
+```
+{% else %}
 ```terminal
 $ sudo apt-get update
 $ sudo apt-get install apt-transport-https
 $ sudo sh -c 'curl https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -'
 $ sudo sh -c 'curl https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list'
 ```
+{% endif %}
 
-Then **install** the Dart SDK:
+Then install the
+{% if site.data.pkg-vers.SDK.channel == 'dev' -%}
+**dev**
+{% else -%}
+**stable**
+{% endif -%}
+release of the Dart SDK:
 
 ```terminal
 $ sudo apt-get update
 $ sudo apt-get install dart
 ```
 
-To setup for a **dev channel** release, run the one-time setup commands
-followed by:
+Or, to install the
+{% if site.data.pkg-vers.SDK.channel == 'dev' -%}
+**stable**
+{% else -%}
+**dev**
+{% endif -%}
+release of the Dart SDK,
+run the one-time setup commands followed by:
 
+{% if site.data.pkg-vers.SDK.channel == 'dev' %}
+```terminal
+$ sudo sh -c 'curl https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list'
+$ sudo apt-get update
+$ sudo apt-get install dart
+```
+{% else %}
 ```terminal
 $ sudo sh -c 'curl https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_unstable.list > /etc/apt/sources.list.d/dart_unstable.list'
 $ sudo apt-get update
 $ sudo apt-get install dart
 ```
+{% endif %}
+
 
 #### Install a Debian package
 

--- a/src/tools/sdk/_mac.md
+++ b/src/tools/sdk/_mac.md
@@ -1,15 +1,31 @@
 [Install homebrew](http://brew.sh/), and then run:
 
+{% if site.data.pkg-vers.SDK.channel == 'dev' %}
+```terminal
+$ brew tap dart-lang/dart
+$ brew install dart --devel
+```
+
+To install a **stable channel** release,
+don't use `--devel`:
+
+```terminal
+$ brew install dart
+```
+
+{% else %}
 ```terminal
 $ brew tap dart-lang/dart
 $ brew install dart
 ```
 
-To install a **dev channel** release use `--devel`:
+To install a **dev channel** release, use `--devel`:
 
 ```terminal
 $ brew install dart --devel
 ```
+{% endif %}
+
 
 ### Upgrade
 
@@ -19,10 +35,19 @@ To upgrade when a new release of Dart is available run:
 $ brew upgrade dart
 ```
 
-To upgrade to a dev channel release when a stable release is currently active run:
+To upgrade to a dev channel release when a stable release is
+currently active, run:
 
 ```terminal
 $ brew upgrade dart --devel --force
+```
+
+To install the most recent stable channel release when
+a more recent dev release is currently active, run:
+
+```terminal
+$ brew uninstall dart
+$ brew install dart
 ```
 
 ### Switch release
@@ -41,5 +66,5 @@ If you aren't sure which versions of dart you have installed, then run:
 $ brew info dart
 ```
 
-The command output includes the latest stable and dev versions at the top, and
-your locally installed versions are listed after that.
+The command output lists the latest stable and dev versions at the top,
+followed by your locally installed versions.

--- a/src/tools/sdk/_windows.md
+++ b/src/tools/sdk/_windows.md
@@ -5,7 +5,28 @@ Choose one of these options:
 
 #### Install using Chocolatey
 
-To use [Chocolatey][] to install a stable release of the Dart SDK, run this
+{% if site.data.pkg-vers.SDK.channel == 'dev' %}
+To use [Chocolatey][] to install a **dev** release of the Dart SDK, run this
+command:
+
+```terminal
+C:\> choco install dart-sdk --pre
+```
+
+To install a **stable** release, run this command:
+
+```terminal
+C:\> choco install dart-sdk
+```
+
+To **upgrade** the dev release of the Dart SDK, run this command:
+(remove the `--pre` to upgrade the stable release):
+
+```terminal
+C:\> choco upgrade dart-sdk --pre
+```
+{% else %}
+To use [Chocolatey][] to install a **stable** release of the Dart SDK, run this
 command:
 
 ```terminal
@@ -24,6 +45,7 @@ To **upgrade** the Dart SDK, run this command
 ```terminal
 C:\> choco upgrade dart-sdk
 ```
+{% endif %}
 
 #### Install using a setup wizard
 

--- a/src/tools/sdk/archive/index.md
+++ b/src/tools/sdk/archive/index.md
@@ -21,27 +21,43 @@ Go to the [Dart SDK page](/tools/sdk).
   {% include_relative _sdk-terms.md %}
 </aside>
 
+
+## Stable channel
+
+{% if site.data.pkg-vers.SDK.channel == 'dev' %}
+The stable channel contains 1.x and earlier versions of Dart.
+We strongly encourage you to use Dart 2 instead,
+which is available in the dev channel.
+{% else %}
+Stable channel builds are tested and approved for production use.
+{% endif %}
+
 <aside class="alert alert-info" markdown="1">
   **Note:** Many Dart 1.x releases include the Dartium browser
   as a downloadable item. Dartium is no longer supported.
   For more information, see the
-  [Dart 2 migration guide for web developers.]({{site.webdev}}/tools/dartium)
+  [Dart 2 migration guide for web developers.]({{site.webdev}}/dart-2#tools)
 {% comment %}
 update-for-dart-2
 {% endcomment %}
 </aside>
 
-## Stable channel
-
-Stable channel builds are tested and approved for production use.
-
 {% include_relative _archives_table.html channel="stable" %}
 
 ## Dev channel
 
+{% if site.data.pkg-vers.SDK.channel == 'dev' %}
+We strongly encourage you to use the most recent dev channel release,
+so that your code will work when Dart 2 is released to the stable channel.
+For more information, see the [Dart 2 page](/dart-2).
+{% comment %}
+update-for-dart-2
+{% endcomment %}
+{% else %}
 Dev channel builds may contain bugs and can provide early access
 to new features. We do not recommended dev channel builds for
 production use.
+{% endif %}
 
 {% include_relative _archives_table.html channel="dev" %}
 

--- a/src/tools/sdk/archive/index.md
+++ b/src/tools/sdk/archive/index.md
@@ -25,8 +25,8 @@ Go to the [Dart SDK page](/tools/sdk).
 ## Stable channel
 
 {% if site.data.pkg-vers.SDK.channel == 'dev' %}
-The stable channel contains 1.x and earlier versions of Dart.
-We strongly encourage you to use Dart 2 instead,
+The stable channel currently contains 1.x and earlier versions of Dart.
+We recommend using Dart 2 instead,
 which is available in the dev channel.
 {% else %}
 Stable channel builds are tested and approved for production use.


### PR DESCRIPTION
Staged:
https://kw-staging-dartlang-2.firebaseapp.com/tools/sdk#install (see all 3 tabs)
https://kw-staging-dartlang-2.firebaseapp.com/tools/sdk/archive

Fixes #22.