### PR TITLE
Make it more obvious how to change from dev to stable channel

### DIFF
--- a/src/tools/sdk/_mac.md
+++ b/src/tools/sdk/_mac.md
@@ -34,20 +34,19 @@ To upgrade when a new release of Dart is available run:
 ```terminal
 $ brew upgrade dart
 ```
+To install a stable channel release when a dev release is currently active,
+run:
+
+```terminal
+$ brew uninstall dart
+$ brew install dart
+```
 
 To upgrade to a dev channel release when a stable release is
 currently active, run:
 
 ```terminal
 $ brew upgrade dart --devel --force
-```
-
-To install the most recent stable channel release when
-a more recent dev release is currently active, run:
-
-```terminal
-$ brew uninstall dart
-$ brew install dart
 ```
 
 ### Switch release

--- a/src/tools/sdk/_mac.md
+++ b/src/tools/sdk/_mac.md
@@ -38,7 +38,7 @@ To install a stable channel release when a dev release is currently active,
 run:
 
 ```terminal
-$ brew uninstall dart
+$ brew unlink dart
 $ brew install dart
 ```
 


### PR DESCRIPTION
Also, don't imply that uninstall is needed only when the dev release is
more recent. I needed it even through stable was newer.

Staged at: https://kw-webdev-dartlang-2.firebaseapp.com/tools/sdk#upgrade
(Mac tab must be selected)