### PR TITLE
Prettify: support `context` argument

### DIFF
--- a/src/_plugins/dart_site_util.rb
+++ b/src/_plugins/dart_site_util.rb
@@ -23,7 +23,7 @@ module DartSite
     #
     # @return a copy of the input lines array, with lines unindented by the
     # maximal amount of whitespace possible without affecting relative
-    # (non-whitespace) line indentation. Also trime off leading and trailing blank lines.
+    # (non-whitespace) line indentation. Also trim off leading and trailing blank lines.
     def self.block_trim_leading_whitespace(lines)
       # 1. Trim leading blank lines
       while lines.first =~ /^\s*$/ do lines.shift; end

--- a/src/_plugins/prettify.rb
+++ b/src/_plugins/prettify.rb
@@ -17,6 +17,9 @@ module Jekyll
     # - The first unnamed optional argument is the prettifier lang argument.
     #   Use 'nocode' or 'none' as the language to turn off prettifying.
     # - class="..."
+    # - context="html". When unspecified, the context is assumed to be markdown.
+    #   In markdown indentation of the block is preserved, in HTML the block
+    #   isn't indented.
     # - tag="...". See [PrettifyCore.code2html()] for a description of
     #   accepted tag specifiers. Defaults to 'pre'.
     #
@@ -37,6 +40,7 @@ module Jekyll
         helper = DartSite::PrettifyCore.new
         helper.code2html(super,
                          lang: @args[:argv1],
+                         context: @args[:context],
                          tag_specifier: @args[:tag],
                          user_classes: @args[:class])
       end

--- a/src/_plugins/prettify_core.rb
+++ b/src/_plugins/prettify_core.rb
@@ -15,7 +15,10 @@ module DartSite
     #   code. The `code` element is used for `code+br`; in addition,
     #   newlines in the code excerpt are reformatted at `<br>` elements.
     # @param user_classes [String] zero or more space separated CSS class names
-    def code2html(code, lang: nil, tag_specifier: 'pre', user_classes: nil)
+    # @param context [String] 'html' or 'markdown' (default), represents whether
+    #   the tag is being rendered in an HTML or a markdown document. Indentation
+    #   must be preserved in markdown and not in HTML.
+    def code2html(code, lang: nil, context: 'markdown', tag_specifier: 'pre', user_classes: nil)
       tag = _get_real_tag(tag_specifier || 'pre')
       css_classes = _css_classes(lang, user_classes)
       class_attr = css_classes.empty? ? '' : " class=\"#{css_classes.join(' ')}\""
@@ -23,7 +26,9 @@ module DartSite
       out = "<#{tag}#{class_attr}>"
       out += '<code>' if tag_specifier == 'pre+code'
 
-      code = Util.block_trim_leading_whitespace(code.split(/\n/)).join("\n")
+      code = context == 'markdown' ?
+                 Util.block_trim_leading_whitespace(code.split(/\n/)).join("\n") :
+                 Util.trim_min_leading_space(code)
       # Strip leading and trailing whitespace so that <pre> and </pre> tags wrap tightly
       code.strip!
       code = CGI.escapeHTML(code)


### PR DESCRIPTION
Fixes #81 

---

<img width="748" alt="screen shot 2019-01-31 at 14 11 14" src="https://user-images.githubusercontent.com/4140793/52078789-16bcb780-2562-11e9-9902-f6e90e51d5b1.png">

See #81, for the "before" appearance of this code excerpt.