### PR TITLE
Fix: shared/ prefix for sidebar includes.

### DIFF
--- a/src/_includes/sidenav-level-1.html
+++ b/src/_includes/sidenav-level-1.html
@@ -30,7 +30,7 @@
       >{{entry1.title}}</a>
 
       <ul class="nav flex-column flex-nowrap collapse {{show}}" id="{{id1}}">
-        {% include sidenav-level-2.html -%}
+        {% include shared/sidenav-level-2.html -%}
       </ul>
     </li>
   {%- endfor -%}

--- a/src/_includes/sidenav-level-2.html
+++ b/src/_includes/sidenav-level-2.html
@@ -52,7 +52,7 @@
     >{{entry2.title}}
     </a>
     <ul class="nav flex-column flex-nowrap collapse {{show}}" id="{{id2}}">
-      {% include sidenav-level-3.html -%}
+      {% include shared/sidenav-level-3.html -%}
     </ul>
   </li>
 {% endif -%}

--- a/src/_includes/sidenav-level-3.html
+++ b/src/_includes/sidenav-level-3.html
@@ -52,7 +52,7 @@
     >{{entry3.title}}
     </a>
     <ul class="nav flex-column flex-nowrap collapse {{show}}" id="{{id3}}">
-      {% include sidenav-level-4.html -%}
+      {% include shared/sidenav-level-4.html -%}
     </ul>
   </li>
 {% endif -%}


### PR DESCRIPTION
Apparently we can have only a single `_includes` directory, and `include_relative` doesn't work either. Referencing the includes by their "absolute" path is the only sane solution.