### PR TITLE
defined travis_fold function 

### DIFF
--- a/tool/before-install.sh
+++ b/tool/before-install.sh
@@ -23,7 +23,13 @@ fi
 
 ./tool/shared/install-dart-sdk.sh
 
-travis_fold() { true; }
+__type_t() { if [[ -n "$ZSH_VERSION" ]]; then whence -w $*; else type -t $*; fi }
+export -f __type_t > /dev/null
+
+if ! __type_t travis_fold > /dev/null; then
+  # In case this is being run locally. Turn travis_fold into a noop.
+  function travis_fold() { true; }
+fi
 
 travis_fold start before_install.pub
   # For now favor running pub upgrade so that we can get the latest code_* packages

--- a/tool/before-install.sh
+++ b/tool/before-install.sh
@@ -23,6 +23,8 @@ fi
 
 ./tool/shared/install-dart-sdk.sh
 
+travis_fold() { true; }
+
 travis_fold start before_install.pub
   # For now favor running pub upgrade so that we can get the latest code_* packages
   # (which are specified in the pubspec via overrides):

--- a/tool/env-set.sh
+++ b/tool/env-set.sh
@@ -57,12 +57,6 @@ elif [[ -z "$DART_SITE_ENV_DEFS" ]]; then
   fi
   source tool/shared/get-ruby.sh "$_DART_SITE_ENV_SET_INSTALL_OPT"
 
-  # if ! __type_t travis_fold > /dev/null; then
-  #   # In case this is being run locally. Turn travis_fold into a noop.
-  #   function travis_fold() { true; }
-  # fi
-  # export -f travis_fold > /dev/null
-
   case "$(uname -a)" in
       Darwin\ *) _OS_NAME=macos ;;
       Linux\ *) _OS_NAME=linux ;;

--- a/tool/env-set.sh
+++ b/tool/env-set.sh
@@ -57,11 +57,11 @@ elif [[ -z "$DART_SITE_ENV_DEFS" ]]; then
   fi
   source tool/shared/get-ruby.sh "$_DART_SITE_ENV_SET_INSTALL_OPT"
 
-  if ! __type_t travis_fold > /dev/null; then
-    # In case this is being run locally. Turn travis_fold into a noop.
-    travis_fold() { true; }
-  fi
-  export -f travis_fold > /dev/null
+  # if ! __type_t travis_fold > /dev/null; then
+  #   # In case this is being run locally. Turn travis_fold into a noop.
+  #   function travis_fold() { true; }
+  # fi
+  # export -f travis_fold > /dev/null
 
   case "$(uname -a)" in
       Darwin\ *) _OS_NAME=macos ;;

--- a/tool/install.sh
+++ b/tool/install.sh
@@ -15,7 +15,13 @@ else
     echo "Node version: $(node --version)"
 fi
 
-travis_fold() { true; }
+__type_t() { if [[ -n "$ZSH_VERSION" ]]; then whence -w $*; else type -t $*; fi }
+export -f __type_t > /dev/null
+
+if ! __type_t travis_fold > /dev/null; then
+  # In case this is being run locally. Turn travis_fold into a noop.
+  function travis_fold() { true; }
+fi
 
 travis_fold start install.npm_install
   (set -x; npm install)

--- a/tool/install.sh
+++ b/tool/install.sh
@@ -15,6 +15,8 @@ else
     echo "Node version: $(node --version)"
 fi
 
+travis_fold() { true; }
+
 travis_fold start install.npm_install
   (set -x; npm install)
 travis_fold end install.npm_install


### PR DESCRIPTION
defined travis_fold function in each script.
Issue, PR: https://github.com/dart-lang/site-www/pull/2310


#### Add info
confirmed that bash and zsh work without `source` command for me .

<details><summary> result with bash</summary><div>

```
bash-3.2$ source ./tool/env-set.sh
Setting environment variables from tool/env-set.sh
v12.16.2 is already installed.
Now using node v12.16.2 (npm v6.14.4)
RVM current: ruby-2.6.5
  Using ruby-2.6.5 (rvm 1.29.9)
Ruby --version: ruby 2.6.5p114 (2019-10-01 revision 67812) [x86_64-darwin18]
INFO: git config push.recurseSubmodules is set to check.
INFO: git config status.submodulesummary is set to 1.


bash-3.2$ ./tool/before-install.sh
Dart SDK appears to be installed: dart is /usr/local/bin/dart
Dart VM version: 2.7.2 (Mon Mar 23 22:11:27 2020 +0100) on "macos_x64"
Resolving dependencies... (29.0s)
  _fe_analyzer_shared 2.2.0
  analyzer 0.39.7
  args 1.6.0
  async 2.4.1
  build 1.2.2
  build_config 0.4.2
  build_daemon 2.1.4
  build_resolvers 1.3.5
  build_runner 1.8.1
  build_runner_core 5.0.0
  built_collection 4.3.2
  built_value 7.0.9
  charcode 1.1.3
  checked_yaml 1.0.2
  code_builder 3.2.1
! code_excerpt_updater 1.1.1 from git https://github.com/chalin/code_excerpt_updater.git at 22a18f (overridden)
! code_excerpter 1.0.0 from git https://github.com/chalin/code_excerpter.git at 0f1650 (overridden)
  collection 1.14.12
  console 3.1.0
  convert 2.1.1
  crypto 2.1.4
  csslib 0.16.1
  dart_style 1.3.4
  fixnum 0.10.11
  glob 1.2.0
  graphs 0.2.0
  html 0.14.0+3
  http_multi_server 2.2.0
  http_parser 3.1.4
  io 0.3.4
  js 0.6.1+1
  json_annotation 3.0.1
  linkcheck 2.0.12
  logging 0.11.4
  matcher 0.12.6
  meta 1.1.8
  mime 0.9.6+3
  node_interop 1.0.3
  node_io 1.0.1+2
  package_config 1.9.3
  path 1.7.0
  pedantic 1.9.0
  pool 1.4.0
  pub_semver 1.4.4
  pubspec_parse 0.1.5
  quiver 2.1.3
  shelf 0.7.5
  shelf_web_socket 0.2.3
  source_span 1.7.0
  stack_trace 1.9.3
  stream_channel 2.0.0
  stream_transform 1.2.0
  string_scanner 1.0.5
  term_glyph 1.1.0
  timing 0.1.1+2
  typed_data 1.1.6
  vector_math 2.0.8
  watcher 0.9.7+14
  web_socket_channel 1.1.0
  yaml 2.2.0
Warning: You are using these overridden dependencies:
! code_excerpt_updater 1.1.1 from git https://github.com/chalin/code_excerpt_updater.git at 22a18f
! code_excerpter 1.0.0 from git https://github.com/chalin/code_excerpter.git at 0f1650
No dependencies changed.


bash-3.2$ ./tool/install.sh
Node version: v12.16.2
+ npm install
audited 2102 packages in 3.043s

4 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities

Bundler version 1.17.3
+ bundle install
Using rake 13.0.1
Using concurrent-ruby 1.1.6
Using i18n 0.9.5
Using minitest 5.14.0
Using thread_safe 0.3.6
Using tzinfo 1.2.6
Using activesupport 5.2.4.2
Using builder 3.2.4
Using erubi 1.9.0
Using mini_portile2 2.4.0
Using nokogiri 1.10.8
Using rails-dom-testing 2.0.3
Using crass 1.0.6
Using loofah 2.4.0
Using rails-html-sanitizer 1.3.0
Using actionview 5.2.4.2
Using rack 2.2.2
Using rack-test 1.1.0
Using actionpack 5.2.4.2
Using public_suffix 4.0.1
Using addressable 2.7.0
Using execjs 2.7.0
Using autoprefixer-rails 9.7.0
Using popper_js 1.14.5
Using method_source 1.0.0
Using thor 1.0.1
Using railties 5.2.4.2
Using ffi 1.12.2
Using sassc 2.2.1
Using sprockets 4.0.0.beta8
Using sprockets-rails 3.2.1
Using tilt 2.0.10
Using sassc-rails 2.1.2
Using bootstrap 4.3.1
Using bundler 1.17.3
Using colorator 1.1.0
Using eventmachine 1.2.7
Using http_parser.rb 0.6.0
Using em-websocket 0.5.1
Using ethon 0.12.0
Using forwardable-extended 2.6.0
Using extras 0.3.0
Using fastimage 2.1.7
Using font-awesome-sass 5.11.2
Using mercenary 0.3.6
Using parallel 1.18.0
Using rainbow 3.0.0
Using typhoeus 1.3.1
Using yell 2.2.0
Using html-proofer 3.13.0
Using rb-fsevent 0.10.3
Using rb-inotify 0.10.0
Using sass-listen 4.0.0
Using sass 3.7.4
Using jekyll-sass-converter 1.5.2
Using listen 3.2.0
Using jekyll-watch 2.2.1
Using kramdown 1.17.0
Using liquid 4.0.3
Using pathutil 0.16.2
Using rouge 3.12.0
Using safe_yaml 1.0.5
Using jekyll 3.8.6
Using jekyll-sanity 1.2.0
Using liquid-tag-parser 1.9.0
Using jekyll-assets 3.0.12
Using jekyll-toc 0.12.2
Using uglifier 4.2.0
Bundle complete! 11 Gemfile dependencies, 68 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
bash-3.2$ exit
```
</div></details>


<details><summary>result with zsh</summary><div>

```
$  source ./tool/env-set.sh
Setting environment variables from tool/env-set.sh
v12.16.2 is already installed.
Now using node v12.16.2 (npm v6.14.4)
RVM current: ruby-2.6.5
  Using ruby-2.6.5 (rvm 1.29.9)
Ruby --version: ruby 2.6.5p114 (2019-10-01 revision 67812) [x86_64-darwin18]
INFO: git config push.recurseSubmodules is set to check.
INFO: git config status.submodulesummary is set to 1.


$  ./tool/before-install.sh
Dart SDK appears to be installed: dart is /usr/local/bin/dart
Dart VM version: 2.7.2 (Mon Mar 23 22:11:27 2020 +0100) on "macos_x64"
Resolving dependencies... (21.5s)
  _fe_analyzer_shared 2.2.0
  analyzer 0.39.7
  args 1.6.0
  async 2.4.1
  build 1.2.2
  build_config 0.4.2
  build_daemon 2.1.4
  build_resolvers 1.3.5
  build_runner 1.8.1
  build_runner_core 5.0.0
  built_collection 4.3.2
  built_value 7.0.9
  charcode 1.1.3
  checked_yaml 1.0.2
  code_builder 3.2.1
! code_excerpt_updater 1.1.1 from git https://github.com/chalin/code_excerpt_updater.git at 22a18f (overridden)
! code_excerpter 1.0.0 from git https://github.com/chalin/code_excerpter.git at 0f1650 (overridden)
  collection 1.14.12
  console 3.1.0
  convert 2.1.1
  crypto 2.1.4
  csslib 0.16.1
  dart_style 1.3.4
  fixnum 0.10.11
  glob 1.2.0
  graphs 0.2.0
  html 0.14.0+3
  http_multi_server 2.2.0
  http_parser 3.1.4
  io 0.3.4
  js 0.6.1+1
  json_annotation 3.0.1
  linkcheck 2.0.12
  logging 0.11.4
  matcher 0.12.6
  meta 1.1.8
  mime 0.9.6+3
  node_interop 1.0.3
  node_io 1.0.1+2
  package_config 1.9.3
  path 1.7.0
  pedantic 1.9.0
  pool 1.4.0
  pub_semver 1.4.4
  pubspec_parse 0.1.5
  quiver 2.1.3
  shelf 0.7.5
  shelf_web_socket 0.2.3
  source_span 1.7.0
  stack_trace 1.9.3
  stream_channel 2.0.0
  stream_transform 1.2.0
  string_scanner 1.0.5
  term_glyph 1.1.0
  timing 0.1.1+2
  typed_data 1.1.6
  vector_math 2.0.8
  watcher 0.9.7+14
  web_socket_channel 1.1.0
  yaml 2.2.0
Warning: You are using these overridden dependencies:
! code_excerpt_updater 1.1.1 from git https://github.com/chalin/code_excerpt_updater.git at 22a18f
! code_excerpter 1.0.0 from git https://github.com/chalin/code_excerpter.git at 0f1650
No dependencies changed.


$  ./tool/install.sh
Node version: v12.16.2
+ npm install
audited 2102 packages in 2.759s

4 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities

Bundler version 1.17.3
+ bundle install
Using rake 13.0.1
Using concurrent-ruby 1.1.6
Using i18n 0.9.5
Using minitest 5.14.0
Using thread_safe 0.3.6
Using tzinfo 1.2.6
Using activesupport 5.2.4.2
Using builder 3.2.4
Using erubi 1.9.0
Using mini_portile2 2.4.0
Using nokogiri 1.10.8
Using rails-dom-testing 2.0.3
Using crass 1.0.6
Using loofah 2.4.0
Using rails-html-sanitizer 1.3.0
Using actionview 5.2.4.2
Using rack 2.2.2
Using rack-test 1.1.0
Using actionpack 5.2.4.2
Using public_suffix 4.0.1
Using addressable 2.7.0
Using execjs 2.7.0
Using autoprefixer-rails 9.7.0
Using popper_js 1.14.5
Using method_source 1.0.0
Using thor 1.0.1
Using railties 5.2.4.2
Using ffi 1.12.2
Using sassc 2.2.1
Using sprockets 4.0.0.beta8
Using sprockets-rails 3.2.1
Using tilt 2.0.10
Using sassc-rails 2.1.2
Using bootstrap 4.3.1
Using bundler 1.17.3
Using colorator 1.1.0
Using eventmachine 1.2.7
Using http_parser.rb 0.6.0
Using em-websocket 0.5.1
Using ethon 0.12.0
Using forwardable-extended 2.6.0
Using extras 0.3.0
Using fastimage 2.1.7
Using font-awesome-sass 5.11.2
Using mercenary 0.3.6
Using parallel 1.18.0
Using rainbow 3.0.0
Using typhoeus 1.3.1
Using yell 2.2.0
Using html-proofer 3.13.0
Using rb-fsevent 0.10.3
Using rb-inotify 0.10.0
Using sass-listen 4.0.0
Using sass 3.7.4
Using jekyll-sass-converter 1.5.2
Using listen 3.2.0
Using jekyll-watch 2.2.1
Using kramdown 1.17.0
Using liquid 4.0.3
Using pathutil 0.16.2
Using rouge 3.12.0
Using safe_yaml 1.0.5
Using jekyll 3.8.6
Using jekyll-sanity 1.2.0
Using liquid-tag-parser 1.9.0
Using jekyll-assets 3.0.12
Using jekyll-toc 0.12.2
Using uglifier 4.2.0
Bundle complete! 11 Gemfile dependencies, 68 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
```
</div></details>