### PR TITLE
Updated highlighting colour

### DIFF
--- a/src/_assets/css/_code_shared.scss
+++ b/src/_assets/css/_code_shared.scss
@@ -11,7 +11,7 @@ pre {
   }
 
   .highlight {
-    background: #ffd557;
+    background: #ffe600;
     padding: 2px;
   }
 }

--- a/src/_assets/css/_code_shared.scss
+++ b/src/_assets/css/_code_shared.scss
@@ -11,7 +11,7 @@ pre {
   }
 
   .highlight {
-    background: #fffde7;
+    background: #ffd557;
     padding: 2px;
   }
 }


### PR DESCRIPTION
Highlighted characters were hard to see against the background, see https://github.com/dart-lang/site-www/issues/2502
![image](https://user-images.githubusercontent.com/11965313/86131222-49fbd100-badd-11ea-916c-c1497c15d668.png)
 vs
![image](https://user-images.githubusercontent.com/11965313/86131306-6861cc80-badd-11ea-8573-2547191bd5f9.png)
