### PR TITLE
Always write CI info when the script is called

### DIFF
--- a/tool/write-ci-info.sh
+++ b/tool/write-ci-info.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-if [[ $TASK != *build* ]]; then exit; fi
-
 FILE=src/_data/ci.yaml
 
 echo "# WARNING: the values in this file get regenerated at build time.


### PR DESCRIPTION
This removes a Travis-specific check that doesn't work on GitHub Actions. On Travis, the file will be written on all tasks, which is harmless because it is a tiny, mostly inconsequential file. On GitHub actions, this fixes the build link in the page footer.

@kwalrath FYI