### PR TITLE
Update to current LTS version of Node

### DIFF
--- a/tool/env-set.sh
+++ b/tool/env-set.sh
@@ -7,7 +7,7 @@
 # - REPO_ROOT contains `_config.yml` with a `port` field.
 
 _DART_SITE_ENV_SET_INSTALL_OPT="--install"
-: ${_DART_SITE_NODE_VERS:=12}
+: ${_DART_SITE_NODE_VERS:=14}
 
 if [[ $# -gt 0 ]]; then
   case "$1" in


### PR DESCRIPTION
Node 12 is just in maintenance mode now and Node 14 is the current LTS version since Oct 2020.

I will followup with the necessary downstream changes and updates in `dart-lang/site-www` and `flutter/website`. They should be minimal though and from initial testing everything seems to be working well.