### PR TITLE
Make upper-right "bug" links use a template

### DIFF
--- a/src/_includes/page-github-links.html
+++ b/src/_includes/page-github-links.html
@@ -8,23 +8,13 @@ Style the button pair using the `#page-github-links` selector.
 {% assign title = page.title | default: page.url -%}
 {% assign url = site.url | append: page.url -%}
 
-{% capture issueTitle -%} title='{{title}}' page issue {%- endcapture -%}
-
-{% assign nl = '%0D%0A' -%}
-{% capture issueBody -%}body=
-Page URL: {{url}}{{nl}}
-Page source: {{path}}{{nl}}
-{{nl}}
-Found a typo? You can fix it yourself by going to the page source and clicking the pencil icon. Or finish creating this issue.{{nl}}
-{{nl}}
-Description of issue:
-{%- endcapture -%}
+{% capture issueTitle -%} title=[PAGE ISSUE]: '{{title}}' {%- endcapture -%}
 
 <div id="page-github-links" class="btn-group" aria-label="Page GitHub links" role="group">
   <a href="{{path}}" class="btn no-automatic-external" title="View page source" target="_blank" rel="noopener">
     <i class="fas fa-file-alt fa-sm"></i>
   </a>
-  <a href="{{repo}}/issues/new?{{issueTitle}}&{{issueBody}}" class="btn no-automatic-external" title="Report an issue with this page"
+  <a href="{{repo}}/issues/new?template=1_page_issue.yml&{{issueTitle}}&page-url={{url}}&page-source={{path}}" class="btn no-automatic-external" title="Report an issue with this page"
     target="_blank" rel="noopener">
     <i class="fas fa-bug fa-sm"></i>
   </a>


### PR DESCRIPTION
Works for dart.dev. Should work for flutter.dev once https://github.com/flutter/website/pull/6099 is merged.