### PR TITLE
Fix missing top level builder function breaking excerpter build

### DIFF
--- a/packages/code_excerpter/lib/builder.dart
+++ b/packages/code_excerpter/lib/builder.dart
@@ -7,6 +7,8 @@ import 'src/util/line.dart';
 
 const excerptLineLeftBorderChar = '|';
 
+Builder builder(BuilderOptions options) => CodeExcerptBuilder(options);
+
 class CodeExcerptBuilder implements Builder {
   static const outputExtension = '.excerpt.yaml';
 

--- a/packages/code_excerpter/test/builder_test.dart
+++ b/packages/code_excerpter/test/builder_test.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:build/build.dart';
 import 'package:code_excerpter/builder.dart';
 import 'package:test/test.dart';
 import 'package:yaml/yaml.dart';
@@ -16,5 +17,9 @@ void main() {
     final buildExtensions = codeExcerpter['build_extensions'] as Map;
     expect(buildExtensions, isNotNull);
     expect(buildExtensions, CodeExcerptBuilder().buildExtensions);
+  });
+
+  test('top-level builder factory function returns a CodeExcerptBuilder', () {
+    expect(builder(BuilderOptions.empty), isA<CodeExcerptBuilder>());
   });
 }


### PR DESCRIPTION
This is causing the builder to fail to build the excerpts downstream.

\cc @domesticmouse or @johnpryan for review, thanks!