### PR TITLE
Skip binary files which cannot be read as a string

### DIFF
--- a/packages/code_excerpter/lib/builder.dart
+++ b/packages/code_excerpter/lib/builder.dart
@@ -21,7 +21,14 @@ class CodeExcerptBuilder implements Builder {
     final assetId = buildStep.inputId;
     if (assetId.package.startsWith(r'$') || assetId.path.endsWith(r'$')) return;
 
-    final content = await buildStep.readAsString(assetId);
+    final String content;
+    try {
+      content = await buildStep.readAsString(assetId);
+    } on FormatException {
+      log.finest('Skipped ${assetId.path} due to failing to read as string.');
+      return;
+    }
+
     final outputAssetId = assetId.addExtension(outputExtension);
 
     final excerpter = Excerpter(assetId.path, content);


### PR DESCRIPTION
I thought I would fix this to unblock the submodule updates since I've taken a look at the excerpter relatively recently. Feel free to close this if you'd like to go with another solution instead.

Fixes https://github.com/flutter/website/issues/7001

\cc @domesticmouse @khanhnwin