### PR TITLE
Enable framed DartPad code excerpts

### DIFF
--- a/src/_plugins/code_excerpt_framer.rb
+++ b/src/_plugins/code_excerpt_framer.rb
@@ -3,14 +3,14 @@ module DartSite
   # Takes the given code excerpt (with the given attributes) and creates
   # some framing HTML: e.g., a div with possible excerpt title in a header.
   class CodeExcerptFramer
-    def frame_code(title, classes, attrs, escaped_code, indent)
-      _unindented_template(title, classes, attrs, escaped_code.gsub('\\','\\\\\\\\'))
+    def frame_code(title, classes, attrs, escaped_code, indent, extra_code_classes)
+      _unindented_template(title, classes, attrs, escaped_code.gsub('\\','\\\\\\\\'), extra_code_classes)
     end
 
     private
     # @param [String] div_classes, in the form "foo bar"
     # @param [Hash] attrs: attributes as attribute-name/value pairs.
-    def _unindented_template(title, _div_classes, attrs, escaped_code)
+    def _unindented_template(title, _div_classes, attrs, escaped_code, extra_code_classes)
       div_classes = ['code-excerpt']
       div_classes << _div_classes if _div_classes
 
@@ -30,8 +30,10 @@ module DartSite
         <div class="#{div_classes * ' '}">
         #{title ? "<div class=\"code-excerpt__header\">#{title}</div>" : '!n'}
         <div class="code-excerpt__code">!n
-          <pre class="#{pre_classes * ' '}">!n
-            escaped_code!n
+          <pre>!n
+            <code class="#{extra_code_classes} #{pre_classes * ' '}">!n
+              escaped_code!n
+            </code>!n
           </pre>!n
         </div>
         </div>

--- a/src/_plugins/code_excerpt_framer.rb
+++ b/src/_plugins/code_excerpt_framer.rb
@@ -3,14 +3,14 @@ module DartSite
   # Takes the given code excerpt (with the given attributes) and creates
   # some framing HTML: e.g., a div with possible excerpt title in a header.
   class CodeExcerptFramer
-    def frame_code(title, classes, attrs, escaped_code, indent, extra_code_classes)
-      _unindented_template(title, classes, attrs, escaped_code.gsub('\\','\\\\\\\\'), extra_code_classes)
+    def frame_code(title, classes, attrs, escaped_code, indent, secondary_class)
+      _unindented_template(title, classes, attrs, escaped_code.gsub('\\','\\\\\\\\'), secondary_class)
     end
 
     private
     # @param [String] div_classes, in the form "foo bar"
     # @param [Hash] attrs: attributes as attribute-name/value pairs.
-    def _unindented_template(title, _div_classes, attrs, escaped_code, extra_code_classes)
+    def _unindented_template(title, _div_classes, attrs, escaped_code, secondary_class)
       div_classes = ['code-excerpt']
       div_classes << _div_classes if _div_classes
 
@@ -31,7 +31,7 @@ module DartSite
         #{title ? "<div class=\"code-excerpt__header\">#{title}</div>" : '!n'}
         <div class="code-excerpt__code">!n
           <pre>!n
-            <code class="#{extra_code_classes} #{pre_classes * ' '}">!n
+            <code class="#{secondary_class} #{pre_classes * ' '}">!n
               escaped_code!n
             </code>!n
           </pre>!n

--- a/src/_plugins/code_excerpt_processor.rb
+++ b/src/_plugins/code_excerpt_processor.rb
@@ -30,7 +30,7 @@ module DartSite
     end
 
     def code_excerpt_regex
-      /^(\s*(<\?(code-\w+)[^>]*>)\n)((\s*)```(\w*)\n(.*?)\n(\s*)```\n?)?/m;
+      /^(\s*(<\?(code-\w+)[^>]*>)\n)((\s*)```((\w*)([^\n]*))\n(.*?)\n(\s*)```\n?)?/m;
     end
 
     def code_excerpt_processing_init
@@ -44,7 +44,8 @@ module DartSite
       args = process_pi_args(pi)
       optional_code_block = match[4]
       indent = match[5]
-      lang = !match[6] || match[6].empty? ? (args['ext'] || 'nocode') : match[6]
+      full_class = match[6]
+      lang = !match[7] || match[7].empty? ? (args['ext'] || 'nocode') : match[7]
       attrs = mk_code_example_directive_attr(lang, args['linenums'])
 
       return process_code_pane(pi, attrs, args) if pi_name == 'code-pane'
@@ -58,7 +59,7 @@ module DartSite
         return ''
       end
 
-      code = match[7]
+      code = match[9]
       leading_whitespace = get_indentation_string(optional_code_block)
       code = Util.trim_min_leading_space(code)
 
@@ -75,7 +76,7 @@ module DartSite
       # because we're rendering the code block as HTML.
       escaped_code = CGI.escapeHTML(code)
 
-      code = @code_framer.frame_code(title, classes, attrs, _process_highlight_markers(escaped_code), indent)
+      code = @code_framer.frame_code(title, classes, attrs, _process_highlight_markers(escaped_code), indent, full_class)
       code.indent!(leading_whitespace.length) if leading_whitespace
       code
     end

--- a/src/_plugins/code_excerpt_processor.rb
+++ b/src/_plugins/code_excerpt_processor.rb
@@ -44,7 +44,7 @@ module DartSite
       args = process_pi_args(pi)
       optional_code_block = match[4]
       indent = match[5]
-      full_class = match[6]
+      secondary_class = match[6]
       lang = !match[7] || match[7].empty? ? (args['ext'] || 'nocode') : match[7]
       attrs = mk_code_example_directive_attr(lang, args['linenums'])
 
@@ -76,7 +76,7 @@ module DartSite
       # because we're rendering the code block as HTML.
       escaped_code = CGI.escapeHTML(code)
 
-      code = @code_framer.frame_code(title, classes, attrs, _process_highlight_markers(escaped_code), indent, full_class)
+      code = @code_framer.frame_code(title, classes, attrs, _process_highlight_markers(escaped_code), indent, secondary_class)
       code.indent!(leading_whitespace.length) if leading_whitespace
       code
     end

--- a/src/_plugins/markdown_with_code_excerpts.rb
+++ b/src/_plugins/markdown_with_code_excerpts.rb
@@ -43,7 +43,7 @@ module Jekyll
     end
 
     class IdentityCodeFramer
-      def frame_code(title, classes, attrs, escaped_code, indent, extra_code_classes)
+      def frame_code(title, classes, attrs, escaped_code, indent, secondary_class)
         escaped_code
       end
     end

--- a/src/_plugins/markdown_with_code_excerpts.rb
+++ b/src/_plugins/markdown_with_code_excerpts.rb
@@ -43,7 +43,7 @@ module Jekyll
     end
 
     class IdentityCodeFramer
-      def frame_code(title, classes, attrs, escaped_code, indent)
+      def frame_code(title, classes, attrs, escaped_code, indent, extra_code_classes)
         escaped_code
       end
     end


### PR DESCRIPTION
This allows multi-file embedded DartPads with code excerpts to work properly, as previously they wouldn't pass the regular expression, not getting the necessary framing.

As a benefit, this allows users with JS disabled to still have proper syntax highlighting.