### PR TITLE
Update logic, scripts, and styles for diff2html

### DIFF
--- a/src/_includes/head-diff2html.html
+++ b/src/_includes/head-diff2html.html
@@ -1,14 +1,22 @@
 {% if page.diff2html -%}
 {% comment %}Get from CDN for now{% endcomment -%}
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/github.min.css">
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/diff2html/2.4.0/diff2html.min.css">
-<script src="https://cdnjs.cloudflare.com/ajax/libs/diff2html/2.4.0/diff2html.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/diff2html/2.4.0/diff2html-ui.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/dart.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/yaml.min.js"></script>
-<script>$(document).ready(function() {
-  var diff2htmlUi = new Diff2HtmlUI();
-  diff2htmlUi.highlightCode(".d2h-wrapper");
-});</script>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.6.0/styles/github.min.css" integrity="sha512-7QTQ5Qsc/IL1k8UU2bkNFjpKTfwnvGuPYE6fzm6yeneWTEGiA3zspgjcTsSgln9m0cn3MgyE7EnDNkF1bB/uCw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/diff2html/2.12.2/diff2html.css" integrity="sha512-5wTRTFfZjM308tVHwxoRX4dRjECvSJQeCsOt2yuZoKe5UACngZ0ihkhGsjfiNef26AjTFl6bNyw+2Gf5JGlTLw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+<script src="https://cdnjs.cloudflare.com/ajax/libs/diff2html/2.12.2/diff2html.min.js" integrity="sha512-8cdb9zL6w8Wyo/efaAxbcA7Gh+lJglOQvChN0clQ7bZQ4BaV5RgBGavSa1pUhVkcWlalyttHMhxPPf9koYmJNw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/diff2html/2.12.2/diff2html-ui.js" integrity="sha512-O6oUIH4/NypmxRX1uQYSXZDE1cTTMXcnZKGeizozCa2bN2YWiH/gkw21FDUZ9SWDCl+Yw5L4OASvZz/Bp5KkEg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.6.0/highlight.min.js" integrity="sha512-zol3kFQ5tnYhL7PzGt0LnllHHVWRGt2bTCIywDiScVvLIlaDOVJ6sPdJTVi0m3rA660RT+yZxkkRzMbb1L8Zkw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.6.0/languages/dart.min.js" integrity="sha512-7XEwLyeyXQMzcKJzj/etI+Nd8+kiUyQdpKos15OOpdwrHIOwRAiLrOBHjm6IKJ/JVqm8jcPwv3J8gTLyELwSHg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.6.0/languages/yaml.min.js" integrity="sha512-+SOjIeQujn8n6mzB4huTBHQGnbF8OaiOOfBMalxIV0YSOSNFdatL+DVCZJj5JLN8XOnpR6v8kkWBpwDCiuWnKw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script>
+function setupDiff() {
+    const diff2htmlUi = new Diff2HtmlUI();
+    diff2htmlUi.highlightCode(".d2h-wrapper");
+}
+
+if (document.readyState !== "loading") {
+  setupDiff();
+} else {
+  document.addEventListener("DOMContentLoaded", setupDiff);
+}
+</script>
 {% endif -%}


### PR DESCRIPTION
- Update to latest compatible versions of diff2html and highlightjs without larger changes
- Add integrity checking to the scripts
- Remove jquery usage

Requires some downstream style changes in flutter/website when landing.

After:
<img width="938" alt="After diff2html example" src="https://user-images.githubusercontent.com/18372958/202327082-a23a623d-e112-48b5-a968-48ee5631f0c9.png">

Before:
<img width="938" alt="Before diff2html example" src="https://user-images.githubusercontent.com/18372958/202327102-734e2d69-2981-4b4c-a302-42a9d7d00199.png">

