### PR TITLE
Update mono_repo to 6.5.7 for dependabot support

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -1,4 +1,4 @@
-# Created with package:mono_repo v6.5.6
+# Created with package:mono_repo v6.5.7
 name: Dart CI
 on:
   push:
@@ -35,7 +35,7 @@ jobs:
         name: Checkout repository
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
       - name: mono_repo self validate
-        run: dart pub global activate mono_repo 6.5.6
+        run: dart pub global activate mono_repo 6.5.7
       - name: mono_repo self validate
         run: dart pub global run mono_repo generate --validate
   job_002:

--- a/tool/ci.sh
+++ b/tool/ci.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Created with package:mono_repo v6.5.6
+# Created with package:mono_repo v6.5.7
 
 # Support built in commands on windows out of the box.
 # When it is a flutter repo (check the pubspec.yaml for "sdk: flutter")


### PR DESCRIPTION
Allows mono_repo to support GitHub action versions updated by dependabot - https://pub.dev/packages/mono_repo/changelog#657