### PR TITLE
Only replace highlight marker if beginning exists too

### DIFF
--- a/src/_plugins/code_excerpt_processor.rb
+++ b/src/_plugins/code_excerpt_processor.rb
@@ -82,8 +82,8 @@ module DartSite
     end
 
     def _process_highlight_markers(s)
-      s.gsub(/\[!/, '<span class="highlight">')
-          .gsub(/!\]/, '</span>')
+      # Only replace [! and !] if both exist
+      s.gsub(/\[!(.*?)!\]/, '<span class="highlight">\1</span>')
     end
 
     def trim_min_leading_space(code)

--- a/src/_plugins/code_excerpt_processor.rb
+++ b/src/_plugins/code_excerpt_processor.rb
@@ -83,7 +83,7 @@ module DartSite
 
     def _process_highlight_markers(s)
       # Only replace [! and !] if both exist
-      s.gsub(/\[!(.*?)!\]/, '<span class="highlight">\1</span>')
+      s.gsub(/\[!(.*?)!\]/m, '<span class="highlight">\1</span>')
     end
 
     def trim_min_leading_space(code)


### PR DESCRIPTION
Fixes https://github.com/dart-lang/site-www/issues/4936

@MaryaBelanger I am not in a position to test this currently, but I think it will fix the issue. Essentially before it replaced the `!]` with the highlight span end even if there was no opening `[!`. When the highlight functionality was implemented the non-null assert operator didn't exist so it likely wasn't considered.

This change makes it so that it only makes the replacement if the `[!` and `!]` both exist.