### PR TITLE
Update analysis defaults to dart_flutter_team_lints v2.1.0

### DIFF
--- a/packages/analysis_defaults/lib/analysis.yaml
+++ b/packages/analysis_defaults/lib/analysis.yaml
@@ -8,7 +8,6 @@ analyzer:
 
 linter:
   rules:
-    - comment_references
     - deprecated_member_use_from_same_package
     - discarded_futures
     - eol_at_end_of_file
@@ -24,4 +23,3 @@ linter:
     - unnecessary_null_aware_operator_on_extension_on_nullable
     - unnecessary_to_list_in_spreads
     - use_enums
-    - use_super_parameters

--- a/packages/analysis_defaults/pubspec.yaml
+++ b/packages/analysis_defaults/pubspec.yaml
@@ -7,4 +7,4 @@ environment:
 
 # NOTE: Code is not allowed in this package. Do not add dependencies.
 dependencies:
-  dart_flutter_team_lints: ^2.0.0
+  dart_flutter_team_lints: ^2.1.0

--- a/packages/analysis_defaults/pubspec.yaml
+++ b/packages/analysis_defaults/pubspec.yaml
@@ -7,4 +7,4 @@ environment:
 
 # NOTE: Code is not allowed in this package. Do not add dependencies.
 dependencies:
-  dart_flutter_team_lints: ^1.0.0
+  dart_flutter_team_lints: ^2.0.0


### PR DESCRIPTION
Also removes the resulting duplicate lints.