### PR TITLE
Move staging container from website to shared repository

### DIFF
--- a/cloud_build/staging_container/Dockerfile
+++ b/cloud_build/staging_container/Dockerfile
@@ -1,0 +1,20 @@
+FROM gcr.io/gcp-runtimes/ubuntu_20_0_4
+
+# Install github cli
+RUN apt update && apt install -y \
+    curl \
+    gpg
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg;
+RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null;
+RUN apt update && apt install -y gh;
+
+# Install node and npm
+RUN mkdir -p /etc/apt/keyrings
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+ENV NODE_MAJOR=20
+RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
+RUN apt-get update
+RUN apt-get install nodejs -y
+
+# Install firebase-tools
+RUN npm install -g firebase-tools

--- a/cloud_build/staging_container/README.md
+++ b/cloud_build/staging_container/README.md
@@ -1,0 +1,11 @@
+This directory contains a Dockerfile that is used for staging the website. The
+following tools are installed to make staging easier:
+
+* Github CLI
+* Node/NPM
+* Firebase Tools
+
+This Dockerfile is currently WIP. The cloud build template in this directory is
+currently manually triggered to build an image and deploy it to Artifact
+Registry, but it can be configured in the future to build automatically on any
+changes to the Dockerfile or cloudbuild template.

--- a/cloud_build/staging_container/cloudbuild.yaml
+++ b/cloud_build/staging_container/cloudbuild.yaml
@@ -1,0 +1,6 @@
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'gcr.io/$PROJECT_ID/firebase-staging', 'cloud_build/staging_container']
+images:
+- 'gcr.io/$PROJECT_ID/firebase-staging'
+tags: ['dash-firebase-staging']


### PR DESCRIPTION
Move the `staging_container` [directory](https://github.com/flutter/website/tree/main/cloud_build/staging_container) from flutter/website to this repository, since it will be used by both dart and flutter.
---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
