### PR TITLE
Update base image of Cloud Build deploy image

### DIFF
--- a/cloud_build/firebase-ghcli/Dockerfile
+++ b/cloud_build/firebase-ghcli/Dockerfile
@@ -1,6 +1,6 @@
-FROM gcr.io/gcp-runtimes/ubuntu_20_0_4
+FROM marketplace.gcr.io/google/debian12
 
-# Install github cli
+# Install the GitHub cli.
 RUN apt update && apt install -y \
     curl \
     gpg
@@ -8,7 +8,7 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | g
 RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null;
 RUN apt update && apt install -y gh;
 
-# Install node and npm
+# Install the latest LTS of Node, which also includes npm.
 RUN mkdir -p /etc/apt/keyrings
 RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
 ENV NODE_MAJOR=20

--- a/cloud_build/firebase-ghcli/README.md
+++ b/cloud_build/firebase-ghcli/README.md
@@ -1,18 +1,20 @@
 ## Summary
-This directory contains a Dockerfile that provides access to firebase tools and
-the Github CLI. This image is used to deploy various Dart/Flutter websites to
-firebase in both production and staging, and is also used to comment on Github
-PRs.
 
+This directory contains a Dockerfile that provides access to
+Node/NPM, Firebase CLI tools, and the GitHub CLI.
+This image is used to deploy various Dart/Flutter websites to
+Firebase in both production and staging, and is
+also used to comment staging links on GitHub PRs.
 
 ## Installed tools
-* Github CLI
+
+* GitHub CLI
 * Node/NPM
 * Firebase Tools
 
-
 ## Additional information
-When the dockerfile or cloud build template in this directory is changed in a
-PR, the cloud build template is triggered and a new version of the image is
-deployed as the latest version in Container Registry under the `flutter-dev`
-project in GCP.
+
+When the `Dockerfile` file or `cloudbuild.yaml` template in this directory
+are changed in a PR, the cloud build template is triggered and
+a new version of the image is deployed as the latest version in
+Container Registry under the `flutter-dev` project in GCP.


### PR DESCRIPTION
Ubuntu 20.04 is getting a bit old, now two LTS behind. To prevent any future incompatibilities and prepare for the end of its LTS support in 2025, update to the latest Debian LTS (12), especially since our tooling might start to require newer dependency versions.

Beyond that, the original base image source `gcr.io/gcp-runtimes` seems to be [no longer updated](https://github.com/GoogleContainerTools/base-images-docker), with no 22.04 image and the last 20.04 image uploaded on Jun 22, 2023. Potentially resulting in security concerns due to lack of security fixes.

I found the new base image from https://cloud.google.com/software-supply-chain-security/docs/base-images which appears to be Google-built, supported, and locally cached.

\cc @khanhnwin for review