### PR TITLE
Update to dart_flutter_team_lints v3

### DIFF
--- a/packages/analysis_defaults/lib/analysis.yaml
+++ b/packages/analysis_defaults/lib/analysis.yaml
@@ -16,7 +16,6 @@ linter:
     - matching_super_parameters
     - no_literal_bool_comparisons
     - no_self_assignments
-    - no_wildcard_variable_uses
     - package_api_docs
     - prefer_final_fields
     - prefer_final_in_for_each

--- a/packages/analysis_defaults/pubspec.yaml
+++ b/packages/analysis_defaults/pubspec.yaml
@@ -3,9 +3,9 @@ description: Analysis defaults for Dart/Flutter site tools.
 publish_to: none
 
 environment:
-  sdk: ^3.2.0
+  sdk: ^3.3.0
 
 # NOTE: Code is not allowed in this package.
 # Do not add dependencies besides the underlying lints package.
 dependencies:
-  dart_flutter_team_lints: ^2.1.1
+  dart_flutter_team_lints: ^3.0.0


### PR DESCRIPTION
`no_wildcard_variable_uses` is now included in `package:lints`, so also remove it from the added rules.