### PR TITLE
Initial structure for shared website styles

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -39,16 +39,16 @@ jobs:
       - name: mono_repo self validate
         run: dart pub global run mono_repo generate --validate
   job_002:
-    name: "analyzer_and_format; Dart 3.5.0; PKGS: pkgs/analysis_defaults, pkgs/excerpter, pkgs/inject_dartpad; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos .`"
+    name: "analyzer_and_format; Dart 3.5.0; PKGS: pkgs/analysis_defaults, pkgs/dash_design, pkgs/excerpter, pkgs/inject_dartpad; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos .`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0;packages:pkgs/analysis_defaults-pkgs/excerpter-pkgs/inject_dartpad;commands:format-analyze"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0;packages:pkgs/analysis_defaults-pkgs/dash_design-pkgs/excerpter-pkgs/inject_dartpad;commands:format-analyze"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0;packages:pkgs/analysis_defaults-pkgs/excerpter-pkgs/inject_dartpad
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0;packages:pkgs/analysis_defaults-pkgs/dash_design-pkgs/excerpter-pkgs/inject_dartpad
             os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
@@ -72,6 +72,19 @@ jobs:
         run: dart analyze --fatal-infos .
         if: "always() && steps.pkgs_analysis_defaults_pub_upgrade.conclusion == 'success'"
         working-directory: pkgs/analysis_defaults
+      - id: pkgs_dash_design_pub_upgrade
+        name: pkgs/dash_design; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/dash_design
+      - name: "pkgs/dash_design; dart format --output=none --set-exit-if-changed ."
+        run: "dart format --output=none --set-exit-if-changed ."
+        if: "always() && steps.pkgs_dash_design_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/dash_design
+      - name: "pkgs/dash_design; dart analyze --fatal-infos ."
+        run: dart analyze --fatal-infos .
+        if: "always() && steps.pkgs_dash_design_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/dash_design
       - id: pkgs_excerpter_pub_upgrade
         name: pkgs/excerpter; dart pub upgrade
         run: dart pub upgrade
@@ -99,16 +112,16 @@ jobs:
         if: "always() && steps.pkgs_inject_dartpad_pub_upgrade.conclusion == 'success'"
         working-directory: pkgs/inject_dartpad
   job_003:
-    name: "analyzer_and_format; Dart dev; PKGS: pkgs/analysis_defaults, pkgs/excerpter, pkgs/inject_dartpad; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos .`"
+    name: "analyzer_and_format; Dart dev; PKGS: pkgs/analysis_defaults, pkgs/dash_design, pkgs/excerpter, pkgs/inject_dartpad; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos .`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/analysis_defaults-pkgs/excerpter-pkgs/inject_dartpad;commands:format-analyze"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/analysis_defaults-pkgs/dash_design-pkgs/excerpter-pkgs/inject_dartpad;commands:format-analyze"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/analysis_defaults-pkgs/excerpter-pkgs/inject_dartpad
+            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/analysis_defaults-pkgs/dash_design-pkgs/excerpter-pkgs/inject_dartpad
             os:ubuntu-latest;pub-cache-hosted;sdk:dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
@@ -132,6 +145,19 @@ jobs:
         run: dart analyze --fatal-infos .
         if: "always() && steps.pkgs_analysis_defaults_pub_upgrade.conclusion == 'success'"
         working-directory: pkgs/analysis_defaults
+      - id: pkgs_dash_design_pub_upgrade
+        name: pkgs/dash_design; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/dash_design
+      - name: "pkgs/dash_design; dart format --output=none --set-exit-if-changed ."
+        run: "dart format --output=none --set-exit-if-changed ."
+        if: "always() && steps.pkgs_dash_design_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/dash_design
+      - name: "pkgs/dash_design; dart analyze --fatal-infos ."
+        run: dart analyze --fatal-infos .
+        if: "always() && steps.pkgs_dash_design_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/dash_design
       - id: pkgs_excerpter_pub_upgrade
         name: pkgs/excerpter; dart pub upgrade
         run: dart pub upgrade

--- a/pkgs/dash_design/LICENSE
+++ b/pkgs/dash_design/LICENSE
@@ -1,0 +1,27 @@
+Copyright 2024, the Dart project authors.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google LLC nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/pkgs/dash_design/README.md
+++ b/pkgs/dash_design/README.md
@@ -1,0 +1,21 @@
+## Shared styles for Dart and Flutter websites
+
+> [!CAUTION]
+> This package and the styles it contains are in progress,
+> and are subject to breakages or removal at any point.
+
+### Usage
+
+To be determined.
+
+### Contributing
+
+Contribution information and guidelines to be added.
+
+### Intended clients
+
+- dart.dev
+- docs.flutter.dev
+- pub.dev
+- api.dart.dev
+- api.flutter.dev

--- a/pkgs/dash_design/analysis_options.yaml
+++ b/pkgs/dash_design/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:analysis_defaults/analysis.yaml

--- a/pkgs/dash_design/lib/styles.scss
+++ b/pkgs/dash_design/lib/styles.scss
@@ -16,7 +16,9 @@
 $google-site: false !default;
 
 :root {
-  @include variables.shared;
+  @include variables.typography;
+
+  @include variables.shared-colors;
 
   @include variables.light-theme;
 

--- a/pkgs/dash_design/lib/styles.scss
+++ b/pkgs/dash_design/lib/styles.scss
@@ -7,9 +7,9 @@
 /// Incorporates all styles and CSS custom properties (variables)
 /// from the dash_design package.
 ///
-/// Variables are added at the `:root` (the `html` element),
-/// and dark mode variables are set if `data-theme=dark`
-/// is added to the `html` element.
+/// Most variables are added at the `:root` (the `html` element),
+/// but dark mode variable overrides are added to the `body` element if
+/// the class `dark-theme` is added to it.
 
 @use 'styles/variables';
 
@@ -17,16 +17,17 @@ $google-site: false !default;
 
 :root {
   @include variables.typography;
-
   @include variables.shared-colors;
 
   @include variables.light-theme;
 
-  &[data-theme=dark] {
-    @include variables.dark-theme;
-  }
-
   @if $google-site {
     @include variables.google-overrides;
+  }
+}
+
+body {
+  &.dark-theme {
+    @include variables.dark-theme;
   }
 }

--- a/pkgs/dash_design/lib/styles.scss
+++ b/pkgs/dash_design/lib/styles.scss
@@ -1,0 +1,30 @@
+// Copyright (c) 2024, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// styles.scss:
+///
+/// Incorporates all styles and CSS custom properties (variables)
+/// from the dash_design package.
+///
+/// Variables are added at the `:root` (the `html` element),
+/// and dark mode variables are set if `data-theme=dark`
+/// is added to the `html` element.
+
+@use 'styles/variables';
+
+$google-site: false !default;
+
+:root {
+  @include variables.shared;
+
+  @include variables.light-theme;
+
+  &[data-theme=dark] {
+    @include variables.dark-theme;
+  }
+
+  @if $google-site {
+    @include variables.google-overrides;
+  }
+}

--- a/pkgs/dash_design/lib/styles/variables.scss
+++ b/pkgs/dash_design/lib/styles/variables.scss
@@ -1,0 +1,44 @@
+// Copyright (c) 2024, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// CSS custom properties (variables) to be used across all themes.
+@mixin shared {
+  // Shared typography style variables.
+
+  /// Used for body text and smaller UI elements, like labels.
+  --dash-default-font-family: 'Roboto', sans-serif;
+
+  /// Used for headlines, titles, and larger UI elements.
+  --dash-display-font-family: 'Roboto', sans-serif;
+
+  /// Used for monospace text, such as code blocks.
+  --dash-mono-font-family: 'Roboto Mono', 'Source Code Pro', 'Cascadia Mono', 'JetBrains Mono', monospace;
+
+  /// Used for icons, such as the magnifying glass for search.
+  --dash-symbol-font-family: 'Material Symbols', 'Material Symbols Outlined';
+}
+
+/// CSS custom properties (variables) to be used for a light theme.
+@mixin light-theme {
+  /// The default text color, used for body text.
+  --dash-on-background-text-color: #212121;
+}
+
+/// CSS custom properties (variables) to be used for a dark theme.
+@mixin dark-theme {
+  --dash-on-background-text-color: #e0e0e0;
+}
+
+/// Styles that can only be used by Google sites,
+/// such as enabling the Google Sans font families.
+///
+/// These overrides should be included after all other variables are defined.
+@mixin google-overrides() {
+  // Non-Google sites, such as self-hosted API docs,
+  // can't use Google Sans or Google Symbols.
+  --dash-default-font-family: 'Google Sans Text', 'Google Sans', 'Roboto', sans-serif;
+  --dash-display-font-family: 'Google Sans', 'Google Sans Text', 'Roboto', sans-serif;
+  --dash-mono-font-family: 'Google Sans Mono', 'Roboto Mono', 'Source Code Pro', 'Cascadia Mono', 'JetBrains Mono', monospace;
+  --dash-symbol-font-family: 'Google Symbols', 'Material Symbols', 'Material Symbols Outlined';
+}

--- a/pkgs/dash_design/lib/styles/variables.scss
+++ b/pkgs/dash_design/lib/styles/variables.scss
@@ -10,16 +10,16 @@
 /// Shared typography CSS variables.
 @mixin typography {
   /// Used for body text and smaller UI elements, like labels.
-  --dash-default-font-family: 'Roboto', sans-serif;
+  --dash-default-fontFamily: 'Roboto', sans-serif;
 
   /// Used for headlines, titles, and larger UI elements.
-  --dash-display-font-family: 'Roboto', sans-serif;
+  --dash-display-fontFamily: 'Roboto', sans-serif;
 
   /// Used for monospace text, such as code blocks.
-  --dash-mono-font-family: 'Roboto Mono', 'Source Code Pro', 'Cascadia Mono', 'JetBrains Mono', monospace;
+  --dash-mono-fontFamily: 'Roboto Mono', 'Source Code Pro', 'Cascadia Mono', 'JetBrains Mono', monospace;
 
   /// Used for icons, such as the magnifying glass for search.
-  --dash-symbol-font-family: 'Material Symbols', 'Material Symbols Outlined';
+  --dash-symbol-fontFamily: 'Material Symbols', 'Material Symbols Outlined';
 }
 
 /// Color-related, theme-agnostic CSS variables.
@@ -30,12 +30,12 @@
 /// Light-theme specific CSS variables.
 @mixin light-theme {
   /// The default text color, used for body text.
-  --dash-on-background-text-color: #212121;
+  --dash-surface-fgColor: #212121;
 }
 
 /// Dark-theme specific CSS variables.
 @mixin dark-theme {
-  --dash-on-background-text-color: #e0e0e0;
+  --dash-surface-fgColor: #e0e0e0;
 }
 
 /// CSS variables that specify values that can only be used by Google sites,
@@ -45,8 +45,8 @@
 @mixin google-overrides {
   // Non-Google sites, such as self-hosted API docs,
   // can't use Google Sans or Google Symbols.
-  --dash-default-font-family: 'Google Sans Text', 'Google Sans', 'Roboto', sans-serif;
-  --dash-display-font-family: 'Google Sans', 'Google Sans Text', 'Roboto', sans-serif;
-  --dash-mono-font-family: 'Google Sans Mono', 'Roboto Mono', 'Source Code Pro', 'Cascadia Mono', 'JetBrains Mono', monospace;
-  --dash-symbol-font-family: 'Google Symbols', 'Material Symbols', 'Material Symbols Outlined';
+  --dash-default-fontFamily: 'Google Sans Text', 'Google Sans', 'Roboto', sans-serif;
+  --dash-display-fontFamily: 'Google Sans', 'Google Sans Text', 'Roboto', sans-serif;
+  --dash-mono-fontFamily: 'Google Sans Mono', 'Roboto Mono', 'Source Code Pro', 'Cascadia Mono', 'JetBrains Mono', monospace;
+  --dash-symbol-fontFamily: 'Google Symbols', 'Material Symbols', 'Material Symbols Outlined';
 }

--- a/pkgs/dash_design/lib/styles/variables.scss
+++ b/pkgs/dash_design/lib/styles/variables.scss
@@ -30,12 +30,12 @@
 /// Light-theme specific CSS variables.
 @mixin light-theme {
   /// The default text color, used for body text.
-  --dash-surface-fgColor: #212121;
+  --dash-surface-fgColor: #4a4a4a;
 }
 
 /// Dark-theme specific CSS variables.
 @mixin dark-theme {
-  --dash-surface-fgColor: #e0e0e0;
+  --dash-surface-fgColor: #dcdcdc;
 }
 
 /// CSS variables that specify values that can only be used by Google sites,

--- a/pkgs/dash_design/lib/styles/variables.scss
+++ b/pkgs/dash_design/lib/styles/variables.scss
@@ -7,10 +7,8 @@
 /// Mixins that can be included to load CSS custom properties (variables)
 /// into any desired scope.
 
-/// CSS custom properties (variables) to be used across all themes.
-@mixin shared {
-  // Shared typography style variables.
-
+/// Shared typography CSS variables.
+@mixin typography {
   /// Used for body text and smaller UI elements, like labels.
   --dash-default-font-family: 'Roboto', sans-serif;
 
@@ -24,18 +22,23 @@
   --dash-symbol-font-family: 'Material Symbols', 'Material Symbols Outlined';
 }
 
-/// CSS custom properties (variables) to be used for a light theme.
+/// Color-related, theme-agnostic CSS variables.
+@mixin shared-colors {
+
+}
+
+/// Light-theme specific CSS variables.
 @mixin light-theme {
   /// The default text color, used for body text.
   --dash-on-background-text-color: #212121;
 }
 
-/// CSS custom properties (variables) to be used for a dark theme.
+/// Dark-theme specific CSS variables.
 @mixin dark-theme {
   --dash-on-background-text-color: #e0e0e0;
 }
 
-/// Styles that can only be used by Google sites,
+/// CSS variables that specify values that can only be used by Google sites,
 /// such as enabling the Google Sans font families.
 ///
 /// These overrides should be included after all other variables are defined.

--- a/pkgs/dash_design/lib/styles/variables.scss
+++ b/pkgs/dash_design/lib/styles/variables.scss
@@ -2,6 +2,11 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+/// styles/variables.scss:
+///
+/// Mixins that can be included to load CSS custom properties (variables)
+/// into any desired scope.
+
 /// CSS custom properties (variables) to be used across all themes.
 @mixin shared {
   // Shared typography style variables.
@@ -34,7 +39,7 @@
 /// such as enabling the Google Sans font families.
 ///
 /// These overrides should be included after all other variables are defined.
-@mixin google-overrides() {
+@mixin google-overrides {
   // Non-Google sites, such as self-hosted API docs,
   // can't use Google Sans or Google Symbols.
   --dash-default-font-family: 'Google Sans Text', 'Google Sans', 'Roboto', sans-serif;

--- a/pkgs/dash_design/mono_pkg.yaml
+++ b/pkgs/dash_design/mono_pkg.yaml
@@ -1,0 +1,9 @@
+sdk:
+- pubspec
+- dev
+
+stages:
+- analyzer_and_format:
+  - group:
+    - format
+    - analyze: --fatal-infos .

--- a/pkgs/dash_design/pubspec.yaml
+++ b/pkgs/dash_design/pubspec.yaml
@@ -1,0 +1,15 @@
+name: dash_design
+description: Shared styles for Dart and Flutter websites.
+version: 0.0.1-wip
+publish_to: none
+repository: https://github.com/dart-lang/site-shared/tree/main/pkgs/dash_design
+
+environment:
+  sdk: ^3.5.0
+
+dev_dependencies:
+  analysis_defaults:
+    path: ../analysis_defaults
+  path: ^1.9.0
+  sass: ^1.79.4
+  test: ^1.25.8

--- a/pkgs/dash_design/test/style_test.dart
+++ b/pkgs/dash_design/test/style_test.dart
@@ -1,0 +1,24 @@
+// Copyright (c) 2024, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:isolate';
+
+import 'package:path/path.dart' as path;
+import 'package:sass/sass.dart' as sass;
+import 'package:test/test.dart';
+
+void main() {
+  test('Can build styles.scss file', () {
+    final compileResult = sass.compileToResult(_stylesPath!);
+    expect(compileResult.css, contains('--dash-default-font-family'));
+  });
+}
+
+String? get _stylesPath {
+  final packageUri = Uri.parse('package:dash_design/styles.scss');
+  final resolvedUri = Isolate.resolvePackageUriSync(packageUri);
+  if (resolvedUri == null) return null;
+  if (!resolvedUri.isScheme('file')) return null;
+  return path.fromUri(resolvedUri);
+}

--- a/pkgs/dash_design/test/style_test.dart
+++ b/pkgs/dash_design/test/style_test.dart
@@ -10,7 +10,8 @@ import 'package:test/test.dart';
 
 void main() {
   test('Can build styles.scss file', () {
-    final compileResult = sass.compileToResult(_stylesPath!);
+    final compileResult = sass.compileToResult(_stylesPath!,
+        fatalDeprecations: sass.Deprecation.values.where((d) => !d.isFuture));
     expect(compileResult.css, contains('--dash-default-font-family'));
   });
 }


### PR DESCRIPTION
### Overview

This PR proposes a general structure for hosting shared styles in this repository. Currently this is primarily CSS custom property (variable) declarations. It is not yet intended to be used by downstream sites, but rather for discussion and determination of what variables can be shared, as well as their values. For now, anything in the package and these files can and will break without notice.

### Proposed structure

The following is a rough initial structure that I came up with. Feel free to suggest large changes or make changes after this lands.

- `pkgs/dash_design`
  A package to contain the styles. They can be depended on by manually copying relevant files or by depending on the `dash_design` package (with a path and/or git dependency for now).
  - `lib/styles.scss`
    A file that can be used directly with all current variables/classes already applied. This applies styles on the `:root` and applies dark mode if `data-theme=dark` on `<html>`. By default this doesn't include Google-specific styles (such as Google Sans), so needs to be configured when used or forwarded:
  
    ```scss
    @forward 'package:dash_design/styles' with (
      $google-site: true
    );
    ```

    This file is also used to test the styles, to make sure they can be built by Dart Sass.
  - `lib/styles`
    If you need more fine grained control, such as on what element dark mode variables are specified, you can use/include the mixins provided by files in this directory.
    
    - `lib/styles/variables.scss`
      Declares mixins that declare relevant CSS custom properties (variables). Currently `shared`, `light-theme`, `dark-theme`, and `google-overrides`. If needed, this can be broken up across different files in the future, into sub-mixins, whatever works best. The first declaration of each variable should contain a comment about the variable and some examples of when it is to be used.
      
### Open questions and TODOs

- [ ] Does this structure make sense? If it were to actually be used, would it work for the downstream sites?
- [ ] Has pub.dev determined a naming scheme for CSS variables that works well or they prefer? Is there a larger standard we should follow? Same goes for mixins. Document our initial decision before landing this, but we should feel free to change if needed.
- [ ] Does relying on `data-theme=dark` on the HTML element work for pub.dev? Or would a class on the body be better?
- [x] As far as I can tell, Sass doesn't support doc comments. So I used Dart's convention of triple backslashes (`///`) for doc comments and double (`//`) for inline comments. Does that make sense or am I missing a different standard?
- [x] Should we make all Sass deprecation warnings fatal for CI?
- [ ] Is there any standard SCSS formatter (or one you like)?
- [ ] Anything else?

\cc @isoos @jonasfj