### PR TITLE
Include Dart beta in Cloud Build stage/deploy image

### DIFF
--- a/cloud_build/firebase-ghcli/Dockerfile
+++ b/cloud_build/firebase-ghcli/Dockerfile
@@ -1,9 +1,15 @@
 FROM marketplace.gcr.io/google/debian12
 
+# Install prerequisite dependencies.
+RUN apt-get update && apt-get install -y curl gpg apt-transport-https
+
+# Install the latest Dart beta.
+RUN wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo gpg --dearmor -o /usr/share/keyrings/dart.gpg \
+RUN echo "deb [signed-by=/usr/share/keyrings/dart.gpg arch=amd64] https://storage.googleapis.com/download.dartlang.org/linux/debian testing main" | tee /etc/apt/sources.list.d/dart_testing.list \
+RUN apt-get update
+RUN apt-get -t testing install -y dart
+
 # Install the GitHub cli.
-RUN apt update && apt install -y \
-    curl \
-    gpg
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg;
 RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null;
 RUN apt update && apt install -y gh;
@@ -16,5 +22,5 @@ RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesourc
 RUN apt-get update
 RUN apt-get install nodejs -y
 
-# Install firebase-tools
+# Install the latest version of firebase-tools globally.
 RUN npm install -g firebase-tools

--- a/cloud_build/firebase-ghcli/README.md
+++ b/cloud_build/firebase-ghcli/README.md
@@ -1,13 +1,14 @@
 ## Summary
 
 This directory contains a Dockerfile that provides access to
-Node/NPM, Firebase CLI tools, and the GitHub CLI.
+Dart, Node/NPM, Firebase CLI tools, and the GitHub CLI.
 This image is used to deploy various Dart/Flutter websites to
 Firebase in both production and staging, and is
 also used to comment staging links on GitHub PRs.
 
 ## Installed tools
 
+* Dart SDK
 * GitHub CLI
 * Node/NPM
 * Firebase Tools


### PR DESCRIPTION
Adding Dart to the image as we want to use Dart in the site build. Using beta as sometimes we depend on upcoming features, particularly when preparing for a new stable release.