### PR TITLE
Update Cloud Build image to latest beta

### DIFF
--- a/cloud_build/firebase-ghcli/Dockerfile
+++ b/cloud_build/firebase-ghcli/Dockerfile
@@ -1,4 +1,4 @@
-FROM dart:beta
+FROM dart:3.10.0-75.1.beta
 
 # Install prerequisite dependencies.
 RUN apt-get update && apt-get install -y curl gpg


### PR DESCRIPTION
Also use a specific release so we can be more explicit about when to update to a future version, avoiding unintended failures.