### PR TITLE
Rewrite inject_dartpad and expose some functionality in library

### DIFF
--- a/pkgs/inject_dartpad/README.md
+++ b/pkgs/inject_dartpad/README.md
@@ -1,14 +1,14 @@
 ## DartPad injection
 
 To embed a DartPad with arbitrary Dart in to your web page, add the
-JS file found at `lib/inject_dartpad.js` with a `<script>` tag,
+JS file found at `lib/inject_dartpad.dart.js` with a `<script>` tag,
 set up to run after the DOM is ready.
 
 This might look something like the following, depending on where
 your version of the JS file is stored.
 
 ```html
-<script defer src="inject_dartpad.js"></script>
+<script defer src="inject_dartpad.dart.js"></script>
 ```
 
 ### Declare code to inject
@@ -42,10 +42,10 @@ this and other behavior, add one or more of the following options:
 - `data-height="<CSS height>"`
   To specify the initial height of the injected iframe element.
 
-### Developing script
+### Develop injection script
 
 To work on the script itself, modify the code within `/web/inject_dartpad.dart`.
 To compile the code to JavaScript, use the latest Dart SDK,
 verify you have the latest dependencies (`dart pub upgrade`), and then
 run `dart run tool/compile.dart`.
-The updated file will be written to `/lib/inject_dartpad.js`.
+The updated file will be written to `/lib/inject_dartpad.dart.js`.

--- a/pkgs/inject_dartpad/example/inject_dartpad_example.dart
+++ b/pkgs/inject_dartpad/example/inject_dartpad_example.dart
@@ -10,7 +10,7 @@ void main() async {
 
   // Initialize the embedded DartPad.
   await dartPad.initialize(
-    addToDocument: (iframe) {
+    onElementCreated: (iframe) {
       // Add any extra styles or attributes to the created iframe.
       iframe.style.height = '560';
 

--- a/pkgs/inject_dartpad/example/inject_dartpad_example.dart
+++ b/pkgs/inject_dartpad/example/inject_dartpad_example.dart
@@ -2,21 +2,27 @@ import 'package:inject_dartpad/inject_dartpad.dart';
 import 'package:web/web.dart' as web;
 
 void main() async {
+  // Create the embedded DartPad instance manager.
   final dartPad = EmbeddedDartPad.create(
     iframeId: 'my-dartpad',
     theme: DartPadTheme.light,
   );
 
+  // Initialize the embedded DartPad.
   await dartPad.initialize(
     addToDocument: (iframe) {
+      // Add any extra styles or attributes to the created iframe.
       iframe.style.height = '560';
 
+      // Add the iframe to the document body.
+      // This is necessary for the embed to load.
       web.document.body!.append(iframe);
     },
   );
 
-  dartPad.updateCode('''
+  // After awaiting initialization, you can update the code in the DartPad.
+  dartPad.updateCode(r'''
 void main() {
-  print("Hello, I'm Dash!");
+  print('Hello, I am Dash!');
 }''');
 }

--- a/pkgs/inject_dartpad/example/inject_dartpad_example.dart
+++ b/pkgs/inject_dartpad/example/inject_dartpad_example.dart
@@ -1,0 +1,22 @@
+import 'package:inject_dartpad/inject_dartpad.dart';
+import 'package:web/web.dart' as web;
+
+void main() async {
+  final dartPad = EmbeddedDartPad.create(
+    iframeId: 'my-dartpad',
+    theme: DartPadTheme.light,
+  );
+
+  await dartPad.initialize(
+    addToDocument: (iframe) {
+      iframe.style.height = '560';
+
+      web.document.body!.append(iframe);
+    },
+  );
+
+  dartPad.updateCode('''
+void main() {
+  print("Hello, I'm Dash!");
+}''');
+}

--- a/pkgs/inject_dartpad/lib/inject_dartpad.dart
+++ b/pkgs/inject_dartpad/lib/inject_dartpad.dart
@@ -23,7 +23,7 @@ import 'package:web/web.dart' as web;
 ///   );
 ///
 ///   await dartPad.initialize(
-///     addToDocument: (iframe) {
+///     onElementCreated: (iframe) {
 ///       iframe.style.height = '560';
 ///
 ///       web.document.body!.append(iframe);
@@ -95,7 +95,7 @@ final class EmbeddedDartPad {
   /// Must be called and awaited before interacting with this instance,
   /// such as updating the DartPad editor's current source code.
   ///
-  /// The created iframe is passed to the [addToDocument] callback,
+  /// The created iframe is passed to the [onElementCreated] callback,
   /// which should be used to add the iframe to the document and
   /// further configure its attributes, such as classes and size.
   ///
@@ -104,13 +104,13 @@ final class EmbeddedDartPad {
   ///
   /// ```dart
   /// await dartPad.initialize(
-  ///   addToDocument: (iframe) {
+  ///   onElementCreated: (iframe) {
   ///     document.getElementById('dartpad-container')!.append(iframe);
   ///   },
   /// );
   /// ```
   Future<void> initialize({
-    required void Function(web.HTMLIFrameElement iframe) addToDocument,
+    required void Function(web.HTMLIFrameElement iframe) onElementCreated,
   }) async {
     if (_initialized) return;
 
@@ -144,7 +144,7 @@ final class EmbeddedDartPad {
 
     // Give the caller a chance to modify other attributes of the iframe and
     // attach it to their desired location in the document.
-    addToDocument(iframe);
+    onElementCreated(iframe);
 
     await _initializedCompleter.future;
   }

--- a/pkgs/inject_dartpad/lib/inject_dartpad.dart
+++ b/pkgs/inject_dartpad/lib/inject_dartpad.dart
@@ -1,0 +1,243 @@
+// Copyright (c) 2025, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:js_interop';
+
+import 'package:web/web.dart' as web;
+
+/// An iframe-embedded DartPad that can be injected into a web page,
+/// then have its source code updated.
+///
+/// Example usage:
+///
+/// ```dart
+/// import 'package:inject_dartpad/inject_dartpad.dart';
+/// import 'package:web/web.dart' as web;
+///
+/// void main() async {
+///   final dartPad = EmbeddedDartPad.create(
+///     iframeId: 'my-dartpad',
+///     theme: DartPadTheme.light,
+///   );
+///
+///   await dartPad.initialize(
+///     addToDocument: (iframe) {
+///       iframe.style.height = '560';
+///
+///       web.document.body!.append(iframe);
+///     },
+///   );
+///
+///   dartPad.updateCode('''
+/// void main() {
+///   print("Hello, I'm Dash!");
+/// }''');
+/// }
+/// ```
+final class EmbeddedDartPad {
+  /// The unique identifier that's used to identify the created DartPad iframe.
+  ///
+  /// This ID is used both as the HTML element `id` and
+  /// as the iframe's `name` attribute for message targeting.
+  final String iframeId;
+
+  /// The full URL of the DartPad iframe including
+  /// all path segments and query parameters.
+  final String _iframeUrl;
+
+  /// Tracks the initialization state of the embedded DartPad.
+  ///
+  /// Completes when the DartPad iframe has loaded and
+  /// sent a 'ready' message indicating it can receive code updates.
+  final Completer<void> _initializedCompleter = Completer();
+
+  /// Creates an embedded DartPad instance with
+  /// the specified [iframeId] and [iframeUrl].
+  EmbeddedDartPad._({required this.iframeId, required String iframeUrl})
+    : _iframeUrl = iframeUrl;
+
+  /// Creates a new embedded DartPad element with the specified configuration.
+  ///
+  /// Once created, the DartPad must be initialized by
+  /// calling and awaiting [initialize].
+  ///
+  /// The [iframeId] is used to identify the created DartPad iframe.
+  /// It must be unique within the document and a valid HTML element ID.
+  ///
+  /// The [scheme] and [host] are used to construct the DartPad iframe URL.
+  /// [scheme] defaults to 'https' and [host] defaults to 'dartpad.dev'.
+  ///
+  /// To control the appearance of the embedded DartPad,
+  /// you can switch to the [embedLayout] and choose a specific [theme].
+  factory EmbeddedDartPad.create({
+    required String iframeId,
+    String? scheme,
+    String? host,
+    bool? embedLayout,
+    DartPadTheme? theme = DartPadTheme.auto,
+  }) {
+    final dartPadUrl = Uri(
+      scheme: scheme ?? 'https',
+      host: host ?? 'dartpad.dev',
+      queryParameters: <String, String>{
+        if (embedLayout ?? true) 'embed': '$embedLayout',
+        if (theme != DartPadTheme.auto) 'theme': '$theme',
+      },
+    ).toString();
+
+    return EmbeddedDartPad._(iframeId: iframeId, iframeUrl: dartPadUrl);
+  }
+
+  /// Creates and initializes the embedded DartPad iframe.
+  ///
+  /// Must be called and awaited before interacting with this instance,
+  /// such as updating the DartPad editor's current source code.
+  ///
+  /// The created iframe is passed to the [addToDocument] callback,
+  /// which should be used to add the iframe to the document and
+  /// further configure its attributes, such as classes and size.
+  ///
+  /// For example, if you want to embed the DartPad in
+  /// a container with an ID of 'dartpad-container':
+  ///
+  /// ```dart
+  /// await dartPad.initialize(
+  ///   addToDocument: (iframe) {
+  ///     document.getElementById('dartpad-container')!.append(iframe);
+  ///   },
+  /// );
+  /// ```
+  Future<void> initialize({
+    required void Function(web.HTMLIFrameElement iframe) addToDocument,
+  }) async {
+    if (_initialized) return;
+
+    late final JSExportedDartFunction readyHandler;
+    readyHandler = (web.MessageEvent event) {
+      if (event.data case _EmbedReadyMessage(type: 'ready', :final sender?)) {
+        if (sender != iframeId) {
+          return;
+        }
+
+        web.window.removeEventListener('message', readyHandler);
+        if (!_initialized) {
+          _initializedCompleter.complete();
+        }
+      }
+    }.toJS;
+
+    web.window.addEventListener('message', readyHandler);
+
+    final iframe = web.HTMLIFrameElement()
+      ..src = _iframeUrl
+      ..id = iframeId
+      ..name = iframeId
+      ..loading = 'lazy'
+      ..allow = 'clipboard-write';
+    addToDocument(iframe);
+
+    await _initializedCompleter.future;
+  }
+
+  /// Updates the source code displayed in the embedded DartPad's editor
+  /// with the specified Dart [code].
+  ///
+  /// The [code] should generally be valid Dart code for
+  /// the latest stable versions of Dart and Flutter.
+  ///
+  /// Should only be called after [initialize] has completed,
+  /// otherwise throws.
+  void updateCode(String code) {
+    if (!_initialized) {
+      throw StateError(
+        'EmbeddedDartPad.initialize must be called and awaited '
+        'before updating the embedded source code.',
+      );
+    }
+
+    _underlyingIframe.contentWindowCrossOrigin?.postMessage(
+      _MessageToDartPad.updateSource(code),
+      _anyTargetOrigin,
+    );
+  }
+
+  /// Whether the DartPad instance has been successfully initialized.
+  ///
+  /// Returns `true` if [initialize] has been called and awaited,
+  /// and the embedded DartPad has signaled that it's ready to receive messages.
+  bool get _initialized => _initializedCompleter.isCompleted;
+
+  /// Retrieves the iframe element from the current page by
+  /// searching with its ID of [iframeId].
+  ///
+  /// If the iframe can't be found, the method throws.
+  /// The often means it wasn't added to the DOM or was removed.
+  web.HTMLIFrameElement get _underlyingIframe {
+    final frame =
+        web.document.getElementById(iframeId) as web.HTMLIFrameElement?;
+    if (frame == null) {
+      throw StateError(
+        'Failed to find iframe with an '
+        'id of $iframeId in the document. '
+        'Have you added the iframe to the document?',
+      );
+    }
+    return frame;
+  }
+}
+
+/// The themes available for an embedded DartPad instance.
+enum DartPadTheme {
+  /// Light theme with a bright background.
+  light,
+
+  /// Dark theme with a dark background.
+  dark,
+
+  /// Theme that relies on DartPad's built-in theme handling.
+  auto,
+}
+
+/// The target origin to be used for cross-frame messages sent to
+/// the DartPad iframe's content window.
+///
+/// Uses '*' to enable communication with DartPad instances
+/// regardless of their actual origin.
+final JSString _anyTargetOrigin = '*'.toJS;
+
+/// Represents a ready message received from the DartPad iframe.
+///
+/// Sent by DartPad when it has finished loading and is ready to
+/// receive code updates by sending it a cross-frame message.
+extension type _EmbedReadyMessage._(JSObject _) {
+  /// The message type, which should be 'ready' for initialization messages.
+  external String? get type;
+
+  /// The sender ID to identify which DartPad instance sent the message.
+  external String? get sender;
+}
+
+/// Represents DartPad's expected format for receiving cross-frame messages
+/// from its parent window, usually the [EmbeddedDartPad] host.
+@anonymous
+extension type _MessageToDartPad._(JSObject _) implements JSObject {
+  /// Creates a JavaScript object with the expected structure for
+  /// updating the source code in an embedded DartPad's editor.
+  external factory _MessageToDartPad._updateSource({
+    required String sourceCode,
+    String type,
+  });
+
+  /// Creates a message to update that can be sent to
+  /// update the source code in an embedded DartPad instance.
+  ///
+  /// The [sourceCode] should generally be valid Dart code for
+  /// the latest stable versions of Dart and Flutter.
+  factory _MessageToDartPad.updateSource(String sourceCode) =>
+      _MessageToDartPad._updateSource(
+        sourceCode: sourceCode,
+        type: 'sourceCode',
+      );
+}

--- a/pkgs/inject_dartpad/lib/inject_dartpad.dart.js
+++ b/pkgs/inject_dartpad/lib/inject_dartpad.dart.js
@@ -75,6 +75,11 @@ if(typeof q=="function"){o=$.zm
 if(o==null)o=$.zm=v.getIsolateTag("_$dart_js")
 Object.defineProperty(q,o,{value:B.vB,enumerable:false,writable:true,configurable:true})
 return B.vB}return B.vB},
+Qi(a,b){if(a<0||a>4294967295)throw A.u(A.TE(a,0,4294967295,"length",null))
+return J.py(new Array(a),b)},
+py(a,b){var s=A.J(a,b.C("jd<0>"))
+s.$flags=1
+return s},
 Ga(a){if(a<256)switch(a){case 9:case 10:case 11:case 12:case 13:case 32:case 133:case 160:return!0
 default:return!1}switch(a){case 5760:case 8192:case 8193:case 8194:case 8195:case 8196:case 8197:case 8198:case 8199:case 8200:case 8201:case 8202:case 8232:case 8233:case 8239:case 8287:case 12288:case 65279:return!0
 default:return!1}},
@@ -178,9 +183,7 @@ a[r]=s}return s},
 Hp(a,b){var s,r,q,p,o,n=null,m=/^\s*[+-]?((0x[a-f0-9]+)|(\d+)|([a-z0-9]+))\s*$/i.exec(a)
 if(m==null)return n
 s=m[3]
-if(b==null){if(s!=null)return parseInt(a,10)
-if(m[2]!=null)return parseInt(a,16)
-return n}if(b<2||b>36)throw A.u(A.TE(b,2,36,"radix",n))
+if(b<2||b>36)throw A.u(A.TE(b,2,36,"radix",n))
 if(b===10&&s!=null)return parseInt(a,10)
 if(b<10||s==null){r=b<=10?47+b:86+b
 q=m[1]
@@ -677,10 +680,10 @@ Au(a){var s=this,r=A.Oz
 if(A.cc(s))r=A.hn
 else if(s===t.K)r=A.Ti
 else if(A.lR(s)){r=A.l4
-if(s===t.x)r=A.Uc
+if(s===t.t)r=A.Uc
 else if(s===t.w)r=A.ra
 else if(s===t.u)r=A.M4
-else if(s===t.B)r=A.cU
+else if(s===t.x)r=A.cU
 else if(s===t.I)r=A.Qk
 else if(s===t.A)r=A.wI}else if(s===t.S)r=A.IZ
 else if(s===t.N)r=A.Bt
@@ -828,7 +831,7 @@ o3(a){var s=v.mangledGlobalNames[a]
 if(s!=null)return s
 return"minified:"+a},
 Qo(a,b){var s=a.tR[b]
-for(;typeof s=="string";)s=a.tR[s]
+while(typeof s=="string")s=a.tR[s]
 return s},
 ai(a,b){var s,r,q,p,o,n=a.eT,m=n[b]
 if(m==null)return A.Ew(a,b,!1)
@@ -1192,7 +1195,7 @@ e=r.c
 d=f.length
 c=e.length
 for(b=0,a=0;a<c;a+=3){a0=e[a]
-for(;!0;){if(b>=d)return!1
+for(;;){if(b>=d)return!1
 a1=f[b]
 b+=3
 if(a0<a1)return!1
@@ -1202,10 +1205,10 @@ continue}g=e[a+1]
 if(a2&&!g)return!1
 g=f[b-1]
 if(!A.We(a3,e[a+2],a7,g,a5))return!1
-break}}for(;b<d;){if(f[b+1])return!1
+break}}while(b<d){if(f[b+1])return!1
 b+=3}return!0},
 pG(a,b,c,d,e){var s,r,q,p,o,n=b.x,m=d.x
-for(;n!==m;){s=a.tR[n]
+while(n!==m){s=a.tR[n]
 if(s==null)return!1
 if(typeof s=="string"){n=s
 continue}r=s[m]
@@ -1298,7 +1301,7 @@ b=B.pd}}else b=B.pd
 else if(t.C.b(a))A.mj(a,b)
 return new A.OH(a,b)},
 A9(a,b,c){var s,r,q,p={},o=p.a=a
-for(;s=o.a,(s&4)!==0;){o=o.c
+while(s=o.a,(s&4)!==0){o=o.c
 p.a=o}if(o===b){s=A.Zb()
 b.i(new A.OH(new A.AT(!0,o,null,"Cannot complete a future with itself"),s))
 return}r=b.a&1
@@ -1316,7 +1319,7 @@ A.HZ(b,q)
 return}b.a^=2
 A.Tk(null,null,b.b,new A.fG(p,b))},
 HZ(a,b){var s,r,q,p,o,n,m,l,k,j,i,h,g={},f=g.a=a
-for(;!0;){s={}
+for(;;){s={}
 r=f.a
 q=(r&16)===0
 p=!q
@@ -1514,18 +1517,11 @@ u5:function u5(){},
 E3:function E3(){},
 Rw:function Rw(a){this.b=0
 this.c=a},
-QA(a,b){var s=A.Hp(a,b)
-if(s!=null)return s
-throw A.u(A.rr(a,null,null))},
 O1(a,b){a=A.r(a,new Error())
 a.stack=b["["](0)
 throw a},
-O8(a,b,c){var s,r,q
-if(a>4294967295)A.vh(A.TE(a,0,4294967295,"length",null))
-s=A.J(new Array(a),c.C("jd<0>"))
-s.$flags=1
-r=s
-if(a!==0)for(s=r.length,q=0;q<s;++q)r[q]=b
+O8(a,b,c,d){var s,r=J.Qi(a,d)
+if(a!==0&&b!=null)for(s=0;s<a;++s)r[s]=b
 return r},
 HM(a){var s
 A.k1(0,"start")
@@ -1539,7 +1535,7 @@ H(a,b,c){var s=J.I(b)
 if(!s.G())return a
 if(c.length===0){do a+=A.d(s.gl())
 while(s.G())}else{a+=A.d(s.gl())
-for(;s.G();)a=a+c+A.d(s.gl())}return a},
+while(s.G())a=a+c+A.d(s.gl())}return a},
 eP(a,b,c,d){var s,r,q,p,o,n="0123456789ABCDEF"
 if(c===B.xM){s=$.z4()
 s=s.b.test(b)}else s=!1
@@ -1586,19 +1582,23 @@ r.a=A.H(r.a,a,", ")}finally{$.p.pop()}s.a+=c
 r=s.a
 return r.charCodeAt(0)==0?r:r},
 mp(a){A.qw(a)},
-Hh(a,b,c){var s,r,q,p,o,n,m="IPv4 address should contain exactly 4 parts",l="each part must be in the range 0..255",k=new A.cS(a),j=new Uint8Array(4)
-for(s=b,r=s,q=0;s<c;++s){p=a.charCodeAt(s)
-if(p!==46){if((p^48)>9)k.$2("invalid character",s)}else{if(q===3)k.$2(m,s)
-o=A.QA(B.xB.Nj(a,r,s),null)
-if(o>255)k.$2(l,r)
-n=q+1
-j[q]=o
-r=s+1
-q=n}}if(q!==3)k.$2(m,c)
-o=A.QA(B.xB.Nj(a,r,c),null)
-if(o>255)k.$2(l,r)
-j[q]=o
-return j},
+Br(a,b,c){throw A.u(A.rr("Illegal IPv4 address, "+a,b,c))},
+Hh(a,b,c,d,e){var s,r,q,p,o,n,m,l,k="invalid character"
+for(s=d.$flags|0,r=b,q=r,p=0,o=0;;){n=q>=c?0:a.charCodeAt(q)
+m=n^48
+if(m<=9){if(o!==0||q===r){o=o*10+m
+if(o<=255){++q
+continue}A.Br("each part must be in the range 0..255",a,r)}A.Br("parts must not have leading zeros",a,r)}if(q===r){if(q===c)break
+A.Br(k,a,q)}l=p+1
+s&2&&A.cW(d)
+d[e+p]=o
+if(n===46){if(l<4){++q
+p=l
+r=q
+o=0
+continue}break}if(q===c){if(l===4)return
+break}A.Br(k,a,q)
+p=l}A.Br("IPv4 address should contain exactly 4 parts",a,q)},
 Xh(a,b,c){var s
 if(b===c)throw A.u(A.rr("Empty IP address",a,b))
 if(a.charCodeAt(b)===118){s=A.lN(a,b,c)
@@ -1606,7 +1606,7 @@ if(s!=null)throw A.u(s)
 return!1}A.eg(a,b,c)
 return!0},
 lN(a,b,c){var s,r,q,p,o="Missing hex-digit in IPvFuture address";++b
-for(s=b;!0;s=r){if(s<c){r=s+1
+for(s=b;;s=r){if(s<c){r=s+1
 q=a.charCodeAt(s)
 if((q^48)<=9)continue
 p=q|32
@@ -1615,33 +1615,51 @@ if(q===46){if(r-1===b)return new A.aE(o,a,r)
 s=r
 break}return new A.aE("Unexpected character",a,r-1)}if(s-1===b)return new A.aE(o,a,s)
 return new A.aE("Missing '.' in IPvFuture address",a,s)}if(s===c)return new A.aE("Missing address in IPvFuture address, host, cursor",null,null)
-for(;!0;){if((u.f.charCodeAt(a.charCodeAt(s))&16)!==0){++s
+for(;;){if((u.f.charCodeAt(a.charCodeAt(s))&16)!==0){++s
 if(s<c)continue
 return null}return new A.aE("Invalid IPvFuture address character",a,s)}},
-eg(a,b,a0){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e=null,d=new A.VC(a),c=new A.JT(d,a)
-if(a.length<2)d.$2("address is too short",e)
-s=A.J([],t.t)
-for(r=b,q=r,p=!1,o=!1;r<a0;++r){n=a.charCodeAt(r)
-if(n===58){if(r===b){++r
-if(a.charCodeAt(r)!==58)d.$2("invalid start colon.",r)
-q=r}if(r===q){if(p)d.$2("only one wildcard `::` is allowed",r)
-s.push(-1)
-p=!0}else s.push(c.$2(q,r))
-q=r+1}else if(n===46)o=!0}if(s.length===0)d.$2("too few parts",e)
-m=q===a0
-l=B.Nm.grZ(s)
-if(m&&l!==-1)d.$2("expected a part after last `:`",a0)
-if(!m)if(!o)s.push(c.$2(q,a0))
-else{k=A.Hh(a,q,a0)
-s.push((k[0]<<8|k[1])>>>0)
-s.push((k[2]<<8|k[3])>>>0)}if(p){if(s.length>7)d.$2("an address with a wildcard must have less than 7 parts",e)}else if(s.length!==8)d.$2("an address without a wildcard must contain exactly 8 parts",e)
-j=new Uint8Array(16)
-for(l=s.length,i=9-l,r=0,h=0;r<l;++r){g=s[r]
-if(g===-1)for(f=0;f<i;++f){j[h]=0
-j[h+1]=0
-h+=2}else{j[h]=B.jn.A(g,8)
-j[h+1]=g&255
-h+=2}}return j},
+eg(a1,a2,a3){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a="an address must contain at most 8 parts",a0=new A.VC(a1)
+if(a3-a2<2)a0.$2("address is too short",null)
+s=new Uint8Array(16)
+r=-1
+q=0
+if(a1.charCodeAt(a2)===58)if(a1.charCodeAt(a2+1)===58){p=a2+2
+o=p
+r=0
+q=1}else{a0.$2("invalid start colon",a2)
+p=a2
+o=p}else{p=a2
+o=p}for(n=0,m=!0;;){l=p>=a3?0:a1.charCodeAt(p)
+$label0$0:{k=l^48
+j=!1
+if(k<=9)i=k
+else{h=l|32
+if(h>=97&&h<=102)i=h-87
+else break $label0$0
+m=j}if(p<o+4){n=n*16+i;++p
+continue}a0.$2("an IPv6 part can contain a maximum of 4 hex digits",o)}if(p>o){if(l===46){if(m){if(q<=6){A.Hh(a1,o,a3,s,q*2)
+q+=2
+p=a3
+break}a0.$2(a,o)}break}g=q*2
+s[g]=B.jn.A(n,8)
+s[g+1]=n&255;++q
+if(l===58){if(q<8){++p
+o=p
+n=0
+m=!0
+continue}a0.$2(a,p)}break}if(l===58){if(r<0){f=q+1;++p
+r=q
+q=f
+o=p
+continue}a0.$2("only one wildcard `::` is allowed",p)}if(r!==q-1)a0.$2("missing part",p)
+break}if(p<a3)a0.$2("invalid character",p)
+if(q<8){if(r<0)a0.$2("an address without a wildcard must contain exactly 8 parts",a3)
+e=r+1
+d=q-e
+if(d>0){c=e*2
+b=16-d*2
+B.NA.YW(s,b,16,s,c)
+B.NA.du(s,c,b,0)}}return s},
 GO(a){if(a==="http")return 80
 if(a==="https")return 443
 return 0},
@@ -1787,14 +1805,11 @@ wF(a,b){var s,r,q,p,o,n
 if(!A.yB(a))return!b?A.C1(a):a
 s=A.J([],t.s)
 for(r=a.split("/"),q=r.length,p=!1,o=0;o<q;++o){n=r[o]
-if(".."===n){p=s.length!==0&&B.Nm.grZ(s)!==".."
-if(p)s.pop()
-else s.push("..")}else{p="."===n
-if(!p)s.push(n)}}r=s.length
-if(r!==0)r=r===1&&s[0].length===0
-else r=!0
-if(r)return"./"
-if(p||B.Nm.grZ(s)==="..")s.push("")
+if(".."===n){if(s.length!==0&&B.Nm.grZ(s)!=="..")s.pop()
+else s.push("..")
+p=!0}else{p="."===n
+if(!p)s.push(n.length===0&&s.length===0?"./":n)}}if(s.length===0)return"./"
+if(p)s.push("")
 if(!b)s[0]=A.C1(s[0])
 return B.Nm.zV(s,"/")},
 C1(a){var s,r,q=a.length
@@ -1834,10 +1849,7 @@ c8:function c8(){},
 Mh:function Mh(){},
 Zd:function Zd(){},
 M:function M(a){this.a=a},
-cS:function cS(a){this.a=a},
 VC:function VC(a){this.a=a},
-JT:function JT(a,b){this.a=a
-this.b=b},
 Dn:function Dn(a,b,c,d,e,f,g){var _=this
 _.a=a
 _.b=b
@@ -1864,7 +1876,7 @@ return new A.i1(a)},
 i1:function i1(a){this.a=a},
 E(){var s=0,r=A.F(t.n),q,p,o,n
 var $async$E=A.l(function(a,b){if(a===1)return A.x(b,r)
-while(true)switch(s){case 0:o=v.G.document.querySelectorAll("pre > code[data-dartpad]:only-child")
+for(;;)switch(s){case 0:o=v.G.document.querySelectorAll("pre > code[data-dartpad]:only-child")
 n=A.J([],t.F)
 for(q=0;q<o.length;++q){p=o.item(q)
 if(p==null)p=A.A(p)
@@ -1874,7 +1886,7 @@ case 2:return A.y(null,r)}})
 return A.D($async$E,r)},
 f(a5,a6){var s=0,r=A.F(t.U),q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4
 var $async$f=A.l(function(a7,a8){if(a7===1)return A.x(a8,r)
-while(true)switch(s){case 0:a4=a5.parentElement
+for(;;)switch(s){case 0:a4=a5.parentElement
 if(a4==null){q=null
 s=1
 break}p=$.Ww().WJ(B.xB.OF(J.C(a5.innerHTML)))
@@ -1914,7 +1926,7 @@ a1=new A.Dn(h,g,m&&B.xB.nC(a0,"//")?"":f,c,a0,e,d).gnD()
 k=new A.vs($.X3,t.D)
 a2=new A.NG(o,a1,new A.Zf(k,t.h))
 s=3
-return A.j(a2.qw(new A.i6(a5,a4,p)),$async$f)
+return A.j(a2.Sl(new A.i6(a5,a4,p)),$async$f)
 case 3:if((k.a&30)===0)A.vh(A.PV("EmbeddedDartPad.initialize must be called and awaited before updating the embedded source code."))
 a3=v.G.document.getElementById(o)
 if(a3==null)A.vh(A.PV("Failed to find iframe with an id of "+o+" in the document. Have you added the iframe to the document?"))
@@ -1971,7 +1983,7 @@ J.Dw.prototype={
 giO(a){return 0},
 "["(a){return String(a)}}
 J.jd.prototype={
-zV(a,b){var s,r=A.O8(a.length,"",t.N)
+zV(a,b){var s,r=A.O8(a.length,"",!1,t.N)
 for(s=0;s<a.length;++s)r[s]=A.d(a[s])
 return r.join(b)},
 XG(a,b){var s,r,q=a.length
@@ -2050,7 +2062,7 @@ Ix(a,b){var s,r
 if(0>=b)return""
 if(b===1||a.length===0)return a
 if(b!==b>>>0)throw A.u(B.Eq)
-for(s=a,r="";!0;){if((b&1)===1)r=s+r
+for(s=a,r="";;){if((b&1)===1)r=s+r
 b=b>>>1
 if(b===0)break
 s+=s}return r},
@@ -2155,7 +2167,7 @@ else{n=m.Fh(o,b)
 if(n>=0)o[n].b=c
 else o.push(m.x4(b,c))}}},
 aN(a,b){var s=this,r=s.e,q=s.r
-for(;r!=null;){b.$2(r.a,r.b)
+while(r!=null){b.$2(r.a,r.b)
 if(q!==s.r)throw A.u(A.a(s))
 r=r.c}},
 u9(a,b,c){var s=a[b]
@@ -2195,7 +2207,10 @@ return s}}
 A.WZ.prototype={
 gbx(a){return B.lb},
 $iy5:1}
-A.eH.prototype={}
+A.eH.prototype={
+Pz(a,b,c,d){var s=A.TE(b,0,c,d,null)
+throw A.u(s)},
+nl(a,b,c,d){if(b>>>0!==b||b>c)this.Pz(a,b,c,d)}}
 A.df.prototype={
 gbx(a){return B.LV},
 $iy5:1}
@@ -2203,7 +2218,20 @@ A.b0.prototype={
 gB(a){return a.length},
 $iXj:1}
 A.Dg.prototype={$izM:1}
-A.DV.prototype={$izM:1}
+A.DV.prototype={
+YW(a,b,c,d,e){var s,r,q
+a.$flags&2&&A.cW(a,5)
+s=a.length
+this.nl(a,b,s,"start")
+this.nl(a,c,s,"end")
+if(b>c)A.vh(A.TE(b,0,c,null,null))
+r=c-b
+if(e<0)A.vh(A.xY(e,null))
+if(16-e<r)A.vh(A.PV("Not enough elements"))
+q=e!==0||16!==r?d.subarray(e,e+r):d
+a.set(q,b)
+return},
+$izM:1}
 A.zU.prototype={
 gbx(a){return B.Vr},
 $iy5:1}
@@ -2524,6 +2552,9 @@ $S:0}
 A.ar.prototype={
 gkz(a){return new A.a7(a,a.length,A.z(a).C("a7<ar.E>"))},
 F(a,b){return a[b]},
+du(a,b,c,d){var s
+A.jB(b,c,a.length)
+for(s=b;s<c;++s)a[s]=d},
 "["(a){return A.k(a,"[","]")}}
 A.il.prototype={
 "["(a){return A.nO(this)}}
@@ -2620,7 +2651,7 @@ A.m.prototype={}
 A.AT.prototype={
 gZ(){return"Invalid argument"+(!this.a?"(s)":"")},
 gN(){return""},
-"["(a){var s=this,r=s.c,q=r==null?"":" ("+r+")",p=s.d,o=p==null?"":": "+p,n=s.gZ()+q+o
+"["(a){var s=this,r=s.c,q=r==null?"":" ("+r+")",p=s.d,o=p==null?"":": "+A.d(p),n=s.gZ()+q+o
 if(!s.a)return n
 return n+s.gN()+": "+A.h(s.gE())},
 gE(){return this.b}}
@@ -2692,19 +2723,9 @@ $iGz:1}
 A.M.prototype={
 "["(a){var s=this.a
 return s.charCodeAt(0)==0?s:s}}
-A.cS.prototype={
-$2(a,b){throw A.u(A.rr("Illegal IPv4 address, "+a,this.a,b))},
-$S:15}
 A.VC.prototype={
 $2(a,b){throw A.u(A.rr("Illegal IPv6 address, "+a,this.a,b))},
-$S:16}
-A.JT.prototype={
-$2(a,b){var s
-if(b-a>4)this.a.$2("an IPv6 part can only contain a maximum of 4 hex digits",a)
-s=A.QA(B.xB.Nj(this.b,a,b),16)
-if(s<0||s>65535)this.a.$2("each part must be in the range of `0x0..0xFFFF`",a)
-return s},
-$S:17}
+$S:15}
 A.Dn.prototype={
 gnD(){var s,r,q,p,o=this,n=o.w
 if(n===$){s=o.a
@@ -2757,7 +2778,7 @@ r=s.a+=r
 if(b!=null&&b.length!==0){s.a=r+"="
 r=A.eP(1,b,B.xM,!0)
 s.a+=r}},
-$S:18}
+$S:16}
 A.fq.prototype={
 $2(a,b){var s,r
 if(b==null||typeof b=="string")this.a.$2(a,b)
@@ -2769,7 +2790,7 @@ Ny(){this.a=Math.max(18,5)},
 WJ(a){var s,r,q,p,o,n,m,l,k,j,i,h,g,f
 if(!B.xB.tg(a,"&"))return a
 s=new A.M("")
-for(r=a.length,q=0;!0;){p=B.xB.XU(a,"&",q)
+for(r=a.length,q=0;;){p=B.xB.XU(a,"&",q)
 if(p===-1){s.a+=B.xB.yn(a,q)
 break}o=s.a+=B.xB.Nj(a,q,p)
 n=this.a
@@ -2783,7 +2804,7 @@ if(i==null)i=-1
 if(i!==-1){s.a=o+A.Lw(i)
 q=p+(l+1)
 continue}}}g=0
-while(!0){if(!(g<268)){q=p
+for(;;){if(!(g<268)){q=p
 h=!1
 break}f=B.uu[g]
 if(B.xB.nC(m,f)){s.a+=B.nO[g]
@@ -2792,9 +2813,9 @@ h=!0
 break}++g}if(!h){s.a+="&";++q}}r=s.a
 return r.charCodeAt(0)==0?r:r}}
 A.NG.prototype={
-qw(a){var s=0,r=A.F(t.n),q,p=this,o,n,m,l,k
-var $async$qw=A.l(function(b,c){if(b===1)return A.x(c,r)
-while(true)switch(s){case 0:k=p.c.a
+Sl(a){var s=0,r=A.F(t.n),q,p=this,o,n,m,l,k
+var $async$Sl=A.l(function(b,c){if(b===1)return A.x(c,r)
+for(;;)switch(s){case 0:k=p.c.a
 if((k.a&30)!==0){s=1
 break}o=A.wX()
 n=new A.Fb(p,o)
@@ -2814,9 +2835,9 @@ l.loading="lazy"
 l.allow="clipboard-write"
 a.$1(l)
 s=3
-return A.j(k,$async$qw)
+return A.j(k,$async$Sl)
 case 3:case 1:return A.y(q,r)}})
-return A.D($async$qw,r)}}
+return A.D($async$Sl,r)}}
 A.Fb.prototype={
 $1(a){var s,r,q,p=a.data,o=null,n=!1
 if(t.m.b(p)){s="ready"===p.type
@@ -2831,7 +2852,7 @@ if(q!==n.a)return
 v.G.window.removeEventListener("message",this.b.D7())
 n=n.c
 if((n.a.a&30)===0)n.tZ()}},
-$S:19}
+$S:17}
 A.dg.prototype={
 qS(){return"DartPadTheme."+this.b}}
 A.i1.prototype={}
@@ -2858,12 +2879,12 @@ s.replaceWith(k)
 if(a.contentWindow==null){k.replaceWith(s)
 A.mp("Failed to inject embedded DartPad with content:\n")
 A.mp(this.c)}},
-$S:20};(function aliases(){var s=J.zh.prototype
+$S:18};(function aliases(){var s=J.zh.prototype
 s.u=s["["]})();(function installTearOffs(){var s=hunkHelpers._static_1,r=hunkHelpers._static_0
 s(A,"EX","ZV",1)
 s(A,"yt","oA",1)
 s(A,"qW","Bz",1)
-s(A,"XJ","tC",21)
+s(A,"XJ","tC",19)
 r(A,"UI","eN",0)})();(function inheritance(){var s=hunkHelpers.mixin,r=hunkHelpers.inherit,q=hunkHelpers.inheritMany
 r(A.Mh,null)
 q(A.Mh,[A.FK,J.vB,A.rY,J.b,A.Ge,A.a7,A.SU,A.Zr,A.te,A.bq,A.XO,A.n,A.il,A.db,A.VR,A.dQ,A.Jc,A.ET,A.lY,A.W3,A.ih,A.OH,A.ru,A.Pf,A.Fe,A.vs,A.OM,A.xI,A.m0,A.ar,A.Uk,A.zF,A.Rw,A.ck,A.k5,A.VS,A.CD,A.aE,A.c8,A.Zd,A.M,A.Dn,A.NG,A.i1])
@@ -2878,7 +2899,7 @@ r(A.W0,A.m)
 q(A.n,[A.Ay,A.E1,A.lc,A.dC,A.VX,A.th,A.ha,A.WM,A.fs,A.ey,A.Xk,A.jZ,A.Fb,A.i6])
 q(A.lc,[A.zx,A.rT])
 r(A.N5,A.il)
-q(A.E1,[A.wN,A.SX,A.Gs,A.TM,A.FZ,A.GA,A.bp,A.cS,A.VC,A.JT,A.IP,A.fq])
+q(A.E1,[A.wN,A.SX,A.Gs,A.TM,A.FZ,A.GA,A.bp,A.VC,A.IP,A.fq])
 q(A.eH,[A.df,A.b0])
 q(A.b0,[A.RG,A.WB])
 r(A.vX,A.RG)
@@ -2901,18 +2922,19 @@ s(A.RG,A.ar)
 s(A.vX,A.SU)
 s(A.WB,A.ar)
 s(A.ZG,A.SU)})()
-var v={G:typeof self!="undefined"?self:globalThis,typeUniverse:{eC:new Map(),tR:{},eT:{},tPV:{},sEA:[]},mangledGlobalNames:{KN:"int",CP:"double",lf:"num",qU:"String",a2:"bool",c8:"Null",zM:"List",Mh:"Object",Z0:"Map",vm:"JSObject"},mangledNames:{},types:["~()","~(~())","c8(@)","c8()","~(KN)","c8(Mh,Gz)","~(qU,@)","@(@)","@(@,qU)","@(qU)","c8(~())","~(@)","c8(@,Gz)","~(KN,@)","~(Mh?,Mh?)","~(qU,KN)","~(qU,KN?)","KN(KN,KN)","~(qU,qU?)","c8(vm)","~(vm)","a2(Mh?)"],interceptorsByTag:null,leafTags:null,arrayRti:Symbol("$ti")}
+var v={G:typeof self!="undefined"?self:globalThis,typeUniverse:{eC:new Map(),tR:{},eT:{},tPV:{},sEA:[]},mangledGlobalNames:{KN:"int",CP:"double",lf:"num",qU:"String",a2:"bool",c8:"Null",zM:"List",Mh:"Object",Z0:"Map",vm:"JSObject"},mangledNames:{},types:["~()","~(~())","c8(@)","c8()","~(KN)","c8(Mh,Gz)","~(qU,@)","@(@)","@(@,qU)","@(qU)","c8(~())","~(@)","c8(@,Gz)","~(KN,@)","~(Mh?,Mh?)","0&(qU,KN?)","~(qU,qU?)","c8(vm)","~(vm)","a2(Mh?)"],interceptorsByTag:null,leafTags:null,arrayRti:Symbol("$ti")}
 A.xb(v.typeUniverse,JSON.parse('{"iC":"zh","kd":"zh","c5":"zh","Fu":"WZ","yE":{"y5":[]},"PE":{"c8":[],"y5":[]},"MF":{"vm":[]},"zh":{"vm":[]},"jd":{"zM":["1"],"vm":[]},"BC":{"rY":[]},"Po":{"jd":["1"],"zM":["1"],"vm":[]},"qI":{"CP":[]},"im":{"CP":[],"KN":[],"y5":[]},"kD":{"CP":[],"y5":[]},"Dr":{"qU":[],"y5":[]},"SH":{"Ge":[]},"W0":{"m":[],"Ge":[]},"az":{"Ge":[]},"vV":{"Ge":[]},"XO":{"Gz":[]},"Eq":{"Ge":[]},"N5":{"il":["1","2"]},"WZ":{"vm":[],"y5":[]},"eH":{"vm":[]},"df":{"vm":[],"y5":[]},"b0":{"Xj":["1"],"vm":[]},"Dg":{"ar":["CP"],"zM":["CP"],"Xj":["CP"],"vm":[]},"DV":{"ar":["KN"],"zM":["KN"],"Xj":["KN"],"vm":[]},"zU":{"ar":["CP"],"zM":["CP"],"Xj":["CP"],"vm":[],"y5":[],"ar.E":"CP"},"fS":{"ar":["CP"],"zM":["CP"],"Xj":["CP"],"vm":[],"y5":[],"ar.E":"CP"},"xj":{"ar":["KN"],"zM":["KN"],"Xj":["KN"],"vm":[],"y5":[],"ar.E":"KN"},"dE":{"ar":["KN"],"zM":["KN"],"Xj":["KN"],"vm":[],"y5":[],"ar.E":"KN"},"Zc":{"ar":["KN"],"zM":["KN"],"Xj":["KN"],"vm":[],"y5":[],"ar.E":"KN"},"wf":{"ar":["KN"],"zM":["KN"],"Xj":["KN"],"vm":[],"y5":[],"ar.E":"KN"},"Pq":{"ar":["KN"],"zM":["KN"],"Xj":["KN"],"vm":[],"y5":[],"ar.E":"KN"},"eE":{"ar":["KN"],"zM":["KN"],"Xj":["KN"],"vm":[],"y5":[],"ar.E":"KN"},"V6":{"ar":["KN"],"zM":["KN"],"Xj":["KN"],"vm":[],"y5":[],"ar.E":"KN"},"u9":{"Ge":[]},"iM":{"m":[],"Ge":[]},"OH":{"Ge":[]},"uH":{"Ge":[]},"Zf":{"Pf":["1"]},"mJ":{"Pf":["1"]},"vs":{"b8":["1"]},"C6":{"Ge":[]},"m":{"Ge":[]},"AT":{"Ge":[]},"bJ":{"Ge":[]},"ub":{"Ge":[]},"ds":{"Ge":[]},"lj":{"Ge":[]},"UV":{"Ge":[]},"k5":{"Ge":[]},"VS":{"Ge":[]},"Zd":{"Gz":[]},"ZX":{"zM":["KN"]},"n6":{"zM":["KN"]},"zt":{"zM":["KN"]},"rF":{"zM":["KN"]},"yc":{"zM":["KN"]},"X6":{"zM":["KN"]},"Pz":{"zM":["KN"]},"oI":{"zM":["CP"]},"cQ":{"zM":["CP"]}}'))
 A.FF(v.typeUniverse,JSON.parse('{"SU":1,"b0":1,"uH":2,"xI":1,"Uk":2,"zF":2}'))
 var u={f:"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\u03f6\x00\u0404\u03f4 \u03f4\u03f6\u01f6\u01f6\u03f6\u03fc\u01f4\u03ff\u03ff\u0584\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u05d4\u01f4\x00\u01f4\x00\u0504\u05c4\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u0400\x00\u0400\u0200\u03f7\u0200\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u0200\u0200\u0200\u03f7\x00",c:"Error handler must accept one Object or one Object and a StackTrace as arguments, and return a value of the returned future's type"}
 var t=(function rtii(){var s=A.q7
-return{C:s("Ge"),Z:s("EH"),F:s("jd<b8<NG?>>"),s:s("jd<qU>"),b:s("jd<@>"),t:s("jd<KN>"),q:s("jd<OH?>"),T:s("PE"),m:s("vm"),g:s("c5"),p:s("Xj<@>"),j:s("zM<@>"),P:s("c8"),K:s("Mh"),L:s("VY"),l:s("Gz"),N:s("qU"),R:s("y5"),_:s("m"),o:s("kd"),h:s("Zf<~>"),c:s("vs<@>"),D:s("vs<~>"),y:s("a2"),i:s("CP"),z:s("@"),v:s("@(Mh)"),Q:s("@(Mh,Gz)"),S:s("KN"),U:s("NG?"),O:s("b8<c8>?"),A:s("vm?"),X:s("Mh?"),w:s("qU?"),u:s("a2?"),I:s("CP?"),x:s("KN?"),B:s("lf?"),H:s("lf"),n:s("~")}})();(function constants(){var s=hunkHelpers.makeConstList
+return{C:s("Ge"),Z:s("EH"),F:s("jd<b8<NG?>>"),s:s("jd<qU>"),b:s("jd<@>"),q:s("jd<OH?>"),T:s("PE"),m:s("vm"),g:s("c5"),p:s("Xj<@>"),j:s("zM<@>"),P:s("c8"),K:s("Mh"),L:s("VY"),l:s("Gz"),N:s("qU"),R:s("y5"),_:s("m"),o:s("kd"),h:s("Zf<~>"),c:s("vs<@>"),D:s("vs<~>"),y:s("a2"),i:s("CP"),z:s("@"),v:s("@(Mh)"),Q:s("@(Mh,Gz)"),S:s("KN"),U:s("NG?"),O:s("b8<c8>?"),A:s("vm?"),X:s("Mh?"),w:s("qU?"),u:s("a2?"),I:s("CP?"),t:s("KN?"),x:s("lf?"),H:s("lf"),n:s("~")}})();(function constants(){var s=hunkHelpers.makeConstList
 B.Ok=J.vB.prototype
 B.Nm=J.jd.prototype
 B.jn=J.im.prototype
 B.xB=J.Dr.prototype
 B.DG=J.c5.prototype
 B.Ub=J.MF.prototype
+B.NA=A.V6.prototype
 B.ZQ=J.iC.prototype
 B.vB=J.kd.prototype
 B.O4=function getTagFallback(o) {

--- a/pkgs/inject_dartpad/lib/inject_dartpad.js
+++ b/pkgs/inject_dartpad/lib/inject_dartpad.js
@@ -1585,6 +1585,7 @@ try{r=s
 r.a=A.H(r.a,a,", ")}finally{$.p.pop()}s.a+=c
 r=s.a
 return r.charCodeAt(0)==0?r:r},
+mp(a){A.qw(a)},
 Hh(a,b,c){var s,r,q,p,o,n,m="IPv4 address should contain exactly 4 parts",l="each part must be in the range 0..255",k=new A.cS(a),j=new Uint8Array(4)
 for(s=b,r=s,q=0;s<c;++s){p=a.charCodeAt(s)
 if(p!==46){if((p^48)>9)k.$2("invalid character",s)}else{if(q===3)k.$2(m,s)
@@ -1866,7 +1867,8 @@ var $async$E=A.l(function(a,b){if(a===1)return A.x(b,r)
 while(true)switch(s){case 0:o=v.G.document.querySelectorAll("pre > code[data-dartpad]:only-child")
 n=A.J([],t.F)
 for(q=0;q<o.length;++q){p=o.item(q)
-n.push(A.f(p==null?A.A(p):p,q))}s=2
+if(p==null)p=A.A(p)
+n.push(A.f(p,"embedded-dartpad-"+q))}s=2
 return A.j(A.v(n,t.U),$async$E)
 case 2:return A.y(null,r)}})
 return A.D($async$E,r)},
@@ -1912,7 +1914,7 @@ a1=new A.Dn(h,g,m&&B.xB.nC(a0,"//")?"":f,c,a0,e,d).gnD()
 k=new A.vs($.X3,t.D)
 a2=new A.NG(o,a1,new A.Zf(k,t.h))
 s=3
-return A.j(a2.qw(new A.i6(a5,a4)),$async$f)
+return A.j(a2.qw(new A.i6(a5,a4,p)),$async$f)
 case 3:if((k.a&30)===0)A.vh(A.PV("EmbeddedDartPad.initialize must be called and awaited before updating the embedded source code."))
 a3=v.G.document.getElementById(o)
 if(a3==null)A.vh(A.PV("Failed to find iframe with an id of "+o+" in the document. Have you added the iframe to the document?"))
@@ -1924,8 +1926,9 @@ s=1
 break
 case 1:return A.y(q,r)}})
 return A.D($async$f,r)},
-i6:function i6(a,b){this.a=a
-this.b=b},
+i6:function i6(a,b,c){this.a=a
+this.b=b
+this.c=c},
 qw(a){if(typeof dartPrint=="function"){dartPrint(a)
 return}if(typeof console=="object"&&typeof console.log!="undefined"){console.log(a)
 return}if(typeof print=="function"){print(a)
@@ -2853,7 +2856,8 @@ k.appendChild(a)
 s=this.b
 s.replaceWith(k)
 if(a.contentWindow==null){k.replaceWith(s)
-A.qw("Failed to inject embedded DartPad with content:\n")}},
+A.mp("Failed to inject embedded DartPad with content:\n")
+A.mp(this.c)}},
 $S:20};(function aliases(){var s=J.zh.prototype
 s.u=s["["]})();(function installTearOffs(){var s=hunkHelpers._static_1,r=hunkHelpers._static_0
 s(A,"EX","ZV",1)

--- a/pkgs/inject_dartpad/lib/inject_dartpad.js
+++ b/pkgs/inject_dartpad/lib/inject_dartpad.js
@@ -24,7 +24,7 @@ a[b]=s
 a[c]=function(){if(a[b]===s){var r=d()
 if(a[b]!==s){A.pR(b)}a[b]=r}var q=a[b]
 a[c]=function(){return q}
-return q}}function makeConstList(a,b){if(b!=null)A.j(a,b)
+return q}}function makeConstList(a,b){if(b!=null)A.J(a,b)
 a.$flags=7
 return a}function convertToFastObject(a){function t(){}t.prototype=a
 new t()
@@ -52,20 +52,20 @@ return a}var hunkHelpers=function(){var s=function(a,b,c,d,e){return function(f,
 return{inherit:inherit,inheritMany:inheritMany,mixin:mixinEasy,mixinHard:mixinHard,installStaticTearOff:installStaticTearOff,installInstanceTearOff:installInstanceTearOff,_instance_0u:s(0,0,null,["$0"],0),_instance_1u:s(0,1,null,["$1"],0),_instance_2u:s(0,2,null,["$2"],0),_instance_0i:s(1,0,null,["$0"],0),_instance_1i:s(1,1,null,["$1"],0),_instance_2i:s(1,2,null,["$2"],0),_static_0:r(0,null,["$0"],0),_static_1:r(1,null,["$1"],0),_static_2:r(2,null,["$2"],0),makeConstList:makeConstList,lazy:lazy,lazyFinal:lazyFinal,updateHolder:updateHolder,convertToFastObject:convertToFastObject,updateTypes:updateTypes,setOrUpdateInterceptorsByTag:setOrUpdateInterceptorsByTag,setOrUpdateLeafTags:setOrUpdateLeafTags}}()
 function initializeDeferredHunk(a){x=v.types.length
 a(hunkHelpers,v,w,$)}var J={
-uM(a,b,c,d){return{i:a,p:b,e:c,x:d}},
-M3(a){var s,r,q,p,o,n=a[v.dispatchPropertyName]
+Qu(a,b,c,d){return{i:a,p:b,e:c,x:d}},
+ks(a){var s,r,q,p,o,n=a[v.dispatchPropertyName]
 if(n==null)if($.Bv==null){A.XD()
 n=a[v.dispatchPropertyName]}if(n!=null){s=n.p
 if(!1===s)return n.i
 if(!0===s)return a
 r=Object.getPrototypeOf(a)
 if(s===r)return n.i
-if(n.e===r)throw A.L(A.SY("Return interceptor for "+A.I(s(a,n))))}q=a.constructor
+if(n.e===r)throw A.u(A.SY("Return interceptor for "+A.d(s(a,n))))}q=a.constructor
 if(q==null)p=null
 else{o=$.zm
 if(o==null)o=$.zm=v.getIsolateTag("_$dart_js")
 p=q[o]}if(p!=null)return p
-p=A.A(a)
+p=A.w3(a)
 if(p!=null)return p
 if(typeof a=="function")return B.DG
 s=Object.getPrototypeOf(a)
@@ -84,53 +84,50 @@ r=a.charCodeAt(s)
 if(r!==32&&r!==13&&!J.Ga(r))break}return b},
 U6(a){if(typeof a=="string")return J.Dr.prototype
 if(a==null)return a
-if(Array.isArray(a))return J.p.prototype
+if(Array.isArray(a))return J.jd.prototype
 if(typeof a!="object"){if(typeof a=="function")return J.c5.prototype
 if(typeof a=="symbol")return J.Dw.prototype
 if(typeof a=="bigint")return J.rQ.prototype
-return a}if(a instanceof A.a)return a
-return J.M3(a)},
-c(a){if(typeof a=="number"){if(Math.floor(a)==a)return J.im.prototype
+return a}if(a instanceof A.Mh)return a
+return J.ks(a)},
+ia(a){if(typeof a=="number"){if(Math.floor(a)==a)return J.im.prototype
 return J.kD.prototype}if(typeof a=="string")return J.Dr.prototype
-if(a==null)return J.CD.prototype
+if(a==null)return J.PE.prototype
 if(typeof a=="boolean")return J.yE.prototype
-if(Array.isArray(a))return J.p.prototype
+if(Array.isArray(a))return J.jd.prototype
 if(typeof a!="object"){if(typeof a=="function")return J.c5.prototype
 if(typeof a=="symbol")return J.Dw.prototype
 if(typeof a=="bigint")return J.rQ.prototype
-return a}if(a instanceof A.a)return a
-return J.M3(a)},
+return a}if(a instanceof A.Mh)return a
+return J.ks(a)},
 w1(a){if(a==null)return a
-if(Array.isArray(a))return J.p.prototype
+if(Array.isArray(a))return J.jd.prototype
 if(typeof a!="object"){if(typeof a=="function")return J.c5.prototype
 if(typeof a=="symbol")return J.Dw.prototype
 if(typeof a=="bigint")return J.rQ.prototype
-return a}if(a instanceof A.a)return a
-return J.M3(a)},
-CR(a){return J.c(a).gbx(a)},
-GA(a,b){return J.w1(a).F(a,b)},
-Hm(a){return J.U6(a).gB(a)},
-IT(a){return J.w1(a).gkz(a)},
-M1(a,b,c){return J.w1(a).E2(a,b,c)},
-Nu(a){return J.c(a).gi(a)},
+return a}if(a instanceof A.Mh)return a
+return J.ks(a)},
+C(a){return J.ia(a)["["](a)},
+CR(a){return J.ia(a).gbx(a)},
+I(a){return J.w1(a).gkz(a)},
+Nu(a){return J.ia(a).giO(a)},
 cf(a,b){if(a==null)return b==null
 if(typeof a!="object")return b!=null&&a===b
-return J.c(a).DN(a,b)},
-n(a){return J.c(a)["["](a)},
+return J.ia(a).DN(a,b)},
 vB:function vB(){},
 yE:function yE(){},
-CD:function CD(){},
+PE:function PE(){},
 MF:function MF(){},
-u0:function u0(){},
+zh:function zh(){},
 iC:function iC(){},
 kd:function kd(){},
 c5:function c5(){},
 rQ:function rQ(){},
 Dw:function Dw(){},
-p:function p(a){this.$ti=a},
-B:function B(){},
+jd:function jd(a){this.$ti=a},
+BC:function BC(){},
 Po:function Po(a){this.$ti=a},
-D:function D(a,b,c){var _=this
+b:function b(a,b,c){var _=this
 _.a=a
 _.b=b
 _.c=0
@@ -147,55 +144,31 @@ if(r<=9)return r
 s=a|32
 if(97<=s&&s<=102)return s-87
 return-1},
-yc(a,b){a=a+b&536870911
-a=a+((a&524287)<<10)&536870911
-return a^a>>>6},
-qL(a){a=a+((a&67108863)<<3)&536870911
-a^=a>>>11
-return a+((a&16383)<<15)&536870911},
-ks(a){var s,r
-for(s=$.Qu.length,r=0;r<s;++r)if(a===$.Qu[r])return!0
+cb(a,b,c){return a},
+o(a){var s,r
+for(s=$.p.length,r=0;r<s;++r)if(a===$.p[r])return!0
 return!1},
-K1(a,b,c,d){if(t.Q.b(a))return new A.xy(a,b,c.C("@<0>").Kq(d).C("xy<1,2>"))
-return new A.i1(a,b,c.C("@<0>").Kq(d).C("i1<1,2>"))},
 Wp(){return new A.lj("No element")},
 SH:function SH(a){this.a=a},
-zl:function zl(){},
-bQ:function bQ(){},
-aL:function aL(){},
 a7:function a7(a,b,c){var _=this
 _.a=a
 _.b=b
 _.c=0
 _.d=null
 _.$ti=c},
-i1:function i1(a,b,c){this.a=a
-this.b=b
-this.$ti=c},
-xy:function xy(a,b,c){this.a=a
-this.b=b
-this.$ti=c},
-MH:function MH(a,b,c){var _=this
-_.a=null
-_.b=a
-_.c=b
-_.$ti=c},
-A8:function A8(a,b,c){this.a=a
-this.b=b
-this.$ti=c},
 SU:function SU(){},
-H(a){var s=v.mangledGlobalNames[a]
+NQ(a){var s=v.mangledGlobalNames[a]
 if(s!=null)return s
 return"minified:"+a},
 wV(a,b){var s
 if(b!=null){s=b.x
 if(s!=null)return s}return t.p.b(a)},
-I(a){var s
+d(a){var s
 if(typeof a=="string")return a
 if(typeof a=="number"){if(a!==0)return""+a}else if(!0===a)return"true"
 else if(!1===a)return"false"
 else if(a==null)return"null"
-s=J.n(a)
+s=J.C(a)
 return s},
 eQ(a){var s,r=$.xu
 if(r==null)r=$.xu=Symbol("identityHashCode")
@@ -207,27 +180,26 @@ if(m==null)return n
 s=m[3]
 if(b==null){if(s!=null)return parseInt(a,10)
 if(m[2]!=null)return parseInt(a,16)
-return n}if(b<2||b>36)throw A.L(A.TE(b,2,36,"radix",n))
+return n}if(b<2||b>36)throw A.u(A.TE(b,2,36,"radix",n))
 if(b===10&&s!=null)return parseInt(a,10)
 if(b<10||s==null){r=b<=10?47+b:86+b
 q=m[1]
 for(p=q.length,o=0;o<p;++o)if((q.charCodeAt(o)|32)>r)return n}return parseInt(a,b)},
-l(a){var s,r,q,p
-if(a instanceof A.a)return A.d(A.z(a),null)
-s=J.c(a)
+lh(a){var s,r,q,p
+if(a instanceof A.Mh)return A.dm(A.z(a),null)
+s=J.ia(a)
 if(s===B.Ok||s===B.Ub||t.o.b(a)){r=B.O4(a)
 if(r!=="Object"&&r!=="")return r
 q=a.constructor
 if(typeof q=="function"){p=q.name
-if(typeof p=="string"&&p!=="Object"&&p!=="")return p}}return A.d(A.z(a),null)},
+if(typeof p=="string"&&p!=="Object"&&p!=="")return p}}return A.dm(A.z(a),null)},
 i(a){var s,r,q
-if(a==null||typeof a=="number"||A.y(a))return J.n(a)
+if(typeof a=="number"||A.L(a))return J.C(a)
 if(typeof a=="string")return JSON.stringify(a)
-if(a instanceof A.t)return a["["](0)
-if(a instanceof A.M)return a.k(!0)
-s=$.u()
+if(a instanceof A.n)return a["["](0)
+s=$.Ve()
 for(r=0;r<1;++r){q=s[r].R(a)
-if(q!=null)return q}return"Instance of '"+A.l(a)+"'"},
+if(q!=null)return q}return"Instance of '"+A.lh(a)+"'"},
 fw(a,b,c){var s,r,q,p
 if(c<=500&&b===0&&c===a.length)return String.fromCharCode.apply(null,a)
 for(s=b,r="";s<c;s=q){q=s+500
@@ -236,27 +208,35 @@ r+=String.fromCharCode.apply(null,a.subarray(s,p))}return r},
 Lw(a){var s
 if(0<=a){if(a<=65535)return String.fromCharCode(a)
 if(a<=1114111){s=a-65536
-return String.fromCharCode((B.jn.P(s,10)|55296)>>>0,s&1023|56320)}}throw A.L(A.TE(a,0,1114111,null,null))},
+return String.fromCharCode((B.jn.A(s,10)|55296)>>>0,s&1023|56320)}}throw A.u(A.TE(a,0,1114111,null,null))},
+LU(a){var s=a.$thrownJsError
+if(s==null)return null
+return A.ts(s)},
+mj(a,b){var s
+if(a.$thrownJsError==null){s=new Error()
+A.r(a,s)
+a.$thrownJsError=s
+s.stack=b["["](0)}},
 au(a,b,c){if(a>c)return A.TE(a,0,c,"start",null)
 if(b!=null)if(b<a||b>c)return A.TE(b,a,c,"end",null)
 return new A.AT(!0,b,"end",null)},
 tL(a){return new A.AT(!0,a,null,null)},
-L(a){return A.r(a,new Error())},
+u(a){return A.r(a,new Error())},
 r(a,b){var s
-if(a==null)a=new A.E()
+if(a==null)a=new A.m()
 b.dartException=a
-s=A.J
+s=A.t
 if("defineProperty" in Object){Object.defineProperty(b,"message",{get:s})
 b.name=""}else b.toString=s
 return b},
-J(){return J.n(this.dartException)},
-v(a,b){throw A.r(a,b==null?new Error():b)},
+t(){return J.C(this.dartException)},
+vh(a,b){throw A.r(a,b==null?new Error():b)},
 cW(a,b,c){var s
 if(b==null)b=0
 if(c==null)c=0
 s=Error()
-A.v(A.HK(a,b,c),s)},
-HK(a,b,c){var s,r,q,p,o,n,m,l,k
+A.vh(A.Bi(a,b,c),s)},
+Bi(a,b,c){var s,r,q,p,o,n,m,l,k
 if(typeof b=="string")s=b
 else{r="[]=;add;removeWhere;retainWhere;removeRange;setRange;setInt8;setInt16;setInt32;setUint8;setUint16;setUint32;setFloat32;setFloat64".split(";")
 q=r.length
@@ -270,14 +250,88 @@ if((m&4)!==0)k="constant "
 else if((m&2)!==0){k="unmodifiable "
 l="an "}else k=(m&1)!==0?"fixed-length ":""
 return new A.ub("'"+s+"': Cannot "+o+" "+l+k+n)},
-lk(a){throw A.L(A.a4(a))},
+q(a){throw A.u(A.a(a))},
+cM(a){var s,r,q,p,o,n
+a=A.eA(a.replace(String({}),"$receiver$"))
+s=a.match(/\\\$[a-zA-Z]+\\\$/g)
+if(s==null)s=A.J([],t.s)
+r=s.indexOf("\\$arguments\\$")
+q=s.indexOf("\\$argumentsExpr\\$")
+p=s.indexOf("\\$expr\\$")
+o=s.indexOf("\\$method\\$")
+n=s.indexOf("\\$receiver\\$")
+return new A.Zr(a.replace(new RegExp("\\\\\\$arguments\\\\\\$","g"),"((?:x|[^x])*)").replace(new RegExp("\\\\\\$argumentsExpr\\\\\\$","g"),"((?:x|[^x])*)").replace(new RegExp("\\\\\\$expr\\\\\\$","g"),"((?:x|[^x])*)").replace(new RegExp("\\\\\\$method\\\\\\$","g"),"((?:x|[^x])*)").replace(new RegExp("\\\\\\$receiver\\\\\\$","g"),"((?:x|[^x])*)"),r,q,p,o,n)},
+S7(a){return function($expr$){var $argumentsExpr$="$arguments$"
+try{$expr$.$method$($argumentsExpr$)}catch(s){return s.message}}(a)},
+Mj(a){return function($expr$){try{$expr$.$method$}catch(s){return s.message}}(a)},
+T3(a,b){var s=b==null,r=s?null:b.method
+return new A.az(a,r,s?null:b.receiver)},
+Ru(a){if(a==null)return new A.te(a)
+if(a instanceof A.bq)return A.tW(a,a.a)
+if(typeof a!=="object")return a
+if("dartException" in a)return A.tW(a,a.dartException)
+return A.tl(a)},
+tW(a,b){if(t.C.b(b))if(b.$thrownJsError==null)b.$thrownJsError=a
+return b},
+tl(a){var s,r,q,p,o,n,m,l,k,j,i,h,g
+if(!("message" in a))return a
+s=a.message
+if("number" in a&&typeof a.number=="number"){r=a.number
+q=r&65535
+if((B.jn.A(r,16)&8191)===10)switch(q){case 438:return A.tW(a,A.T3(A.d(s)+" (Error "+q+")",null))
+case 445:case 5007:A.d(s)
+return A.tW(a,new A.W0())}}if(a instanceof TypeError){p=$.Sn()
+o=$.lq()
+n=$.N9()
+m=$.iI()
+l=$.UN()
+k=$.Zh()
+j=$.rN()
+$.c3()
+i=$.HK()
+h=$.r1()
+g=p.q(s)
+if(g!=null)return A.tW(a,A.T3(s,g))
+else{g=o.q(s)
+if(g!=null){g.method="call"
+return A.tW(a,A.T3(s,g))}else if(n.q(s)!=null||m.q(s)!=null||l.q(s)!=null||k.q(s)!=null||j.q(s)!=null||m.q(s)!=null||i.q(s)!=null||h.q(s)!=null)return A.tW(a,new A.W0())}return A.tW(a,new A.vV(typeof s=="string"?s:""))}if(a instanceof RangeError){if(typeof s=="string"&&s.indexOf("call stack")!==-1)return new A.VS()
+s=function(b){try{return String(b)}catch(f){}return null}(a)
+return A.tW(a,new A.AT(!1,null,null,typeof s=="string"?s.replace(/^RangeError:\s*/,""):s))}if(typeof InternalError=="function"&&a instanceof InternalError)if(typeof s=="string"&&s==="too much recursion")return new A.VS()
+return a},
+ts(a){var s
+if(a instanceof A.bq)return a.b
+if(a==null)return new A.XO(a)
+s=a.$cachedTrace
+if(s!=null)return s
+s=new A.XO(a)
+if(typeof a==="object")a.$cachedTrace=s
+return s},
 CU(a){if(a==null)return J.Nu(a)
 if(typeof a=="object")return A.eQ(a)
 return J.Nu(a)},
-dJ(a,b){var s,r,q,p=a.length
-for(s=0;s<p;s=q){r=s+1
-q=r+1
-b.t(0,a[s],a[r])}return b},
+pp(a,b,c,d,e,f){switch(b){case 0:return a.$0()
+case 1:return a.$1(c)
+case 2:return a.$2(c,d)
+case 3:return a.$3(c,d,e)
+case 4:return a.$4(c,d,e,f)}throw A.u(new A.CD("Unsupported number of arguments for wrapped closure"))},
+tR(a,b){var s=a.$identity
+if(!!s)return s
+s=A.co(a,b)
+a.$identity=s
+return s},
+co(a,b){var s
+switch(b){case 0:s=a.$0
+break
+case 1:s=a.$1
+break
+case 2:s=a.$2
+break
+case 3:s=a.$3
+break
+case 4:s=a.$4
+break
+default:s=null}if(s!=null)return s.bind(a)
+return function(c,d,e){return function(f,g,h,i){return e(c,d,f,g,h,i)}}(a,b,A.pp)},
 iA(a2){var s,r,q,p,o,n,m,l,k,j,i=a2.co,h=a2.iS,g=a2.iI,f=a2.nDA,e=a2.aI,d=a2.fs,c=a2.cs,b=d[0],a=c[0],a0=i[b],a1=a2.fT
 a1.toString
 s=h?Object.create(new A.zx().constructor.prototype):Object.create(new A.rT(null,null).constructor.prototype)
@@ -290,7 +344,7 @@ s.$_target=a0
 q=!h
 if(q)p=A.bx(b,a0,g,f)
 else{s.$static_name=b
-p=a0}s.$S=A.fm(a1,h,g)
+p=a0}s.$S=A.K(a1,h,g)
 s[a]=p
 for(o=p,n=1;n<d.length;++n){m=d[n]
 if(typeof m=="string"){l=i[m]
@@ -302,9 +356,9 @@ s[j]=m}if(n===e)o=m}s.$C=o
 s.$R=a2.rC
 s.$D=a2.dV
 return r},
-fm(a,b,c){if(typeof a=="number")return a
-if(typeof a=="string"){if(b)throw A.L("Cannot compute signature for static tearoff.")
-return function(d,e){return function(){return e(this,d)}}(a,A.Tn)}throw A.L("Error in functionType of tearoff")},
+K(a,b,c){if(typeof a=="number")return a
+if(typeof a=="string"){if(b)throw A.u("Cannot compute signature for static tearoff.")
+return function(d,e){return function(){return e(this,d)}}(a,A.Tn)}throw A.u("Error in functionType of tearoff")},
 vq(a,b,c,d){var s=A.yS
 switch(b?-1:a){case 0:return function(e,f){return function(){return f(this)[e]()}}(c,s)
 case 1:return function(e,f){return function(g){return f(this)[e](g)}}(c,s)
@@ -316,7 +370,7 @@ default:return function(e,f){return function(){return e.apply(f(this),arguments)
 bx(a,b,c,d){if(c)return A.Hf(a,b,d)
 return A.vq(b.length,d,a,b)},
 Z4(a,b,c,d){var s=A.yS,r=A.AO
-switch(b?-1:a){case 0:throw A.L(new A.Eq("Intercepted function with no arguments."))
+switch(b?-1:a){case 0:throw A.u(new A.Eq("Intercepted function with no arguments."))
 case 1:return function(e,f,g){return function(){return f(this)[e](g(this))}}(c,r,s)
 case 2:return function(e,f,g){return function(h){return f(this)[e](g(this),h)}}(c,r,s)
 case 3:return function(e,f,g){return function(h,i){return f(this)[e](g(this),h,i)}}(c,r,s)
@@ -333,16 +387,16 @@ s=b.length
 r=A.Z4(s,c,a,b)
 return r},
 qm(a){return A.iA(a)},
-Tn(a,b){return A.cE(v.typeUniverse,A.z(a.a),b)},
+Tn(a,b){return A.B(v.typeUniverse,A.z(a.a),b)},
 yS(a){return a.a},
 AO(a){return a.b},
 L4(a){var s,r,q,p=new A.rT("receiver","interceptor"),o=Object.getOwnPropertyNames(p)
 o.$flags=1
 s=o
 for(o=s.length,r=0;r<o;++r){q=s[r]
-if(p[q]===a)return q}throw A.L(A.q("Field name "+a+" not found."))},
-Yg(a){return v.getIsolateTag(a)},
-A(a){var s,r,q,p,o,n=$.NF.$1(a),m=$.nw[n]
+if(p[q]===a)return q}throw A.u(A.xY("Field name "+a+" not found.",null))},
+e(a){return v.getIsolateTag(a)},
+w3(a){var s,r,q,p,o,n=$.NF.$1(a),m=$.nw[n]
 if(m!=null){Object.defineProperty(a,v.dispatchPropertyName,{value:m,enumerable:false,writable:true,configurable:true})
 return m.i}s=$.vv[n]
 if(s!=null)return s
@@ -363,17 +417,17 @@ return m.i}if(p==="~"){$.vv[n]=s
 return s}if(p==="-"){o=A.Va(s)
 Object.defineProperty(Object.getPrototypeOf(a),v.dispatchPropertyName,{value:o,enumerable:false,writable:true,configurable:true})
 return o.i}if(p==="+")return A.Lc(a,s)
-if(p==="*")throw A.L(A.SY(n))
+if(p==="*")throw A.u(A.SY(n))
 if(v.leafTags[n]===true){o=A.Va(s)
 Object.defineProperty(Object.getPrototypeOf(a),v.dispatchPropertyName,{value:o,enumerable:false,writable:true,configurable:true})
 return o.i}else return A.Lc(a,s)},
 Lc(a,b){var s=Object.getPrototypeOf(a)
-Object.defineProperty(s,v.dispatchPropertyName,{value:J.uM(b,s,null,null),enumerable:false,writable:true,configurable:true})
+Object.defineProperty(s,v.dispatchPropertyName,{value:J.Qu(b,s,null,null),enumerable:false,writable:true,configurable:true})
 return b},
-Va(a){return J.uM(a,!1,null,!!a.$iXj)},
+Va(a){return J.Qu(a,!1,null,!!a.$iXj)},
 VF(a,b,c){var s=b.prototype
 if(v.leafTags[a]===true)return A.Va(s)
-else return J.uM(s,c,null,null)},
+else return J.Qu(s,c,null,null)},
 XD(){if(!0===$.Bv)return
 $.Bv=!0
 A.Z1()},
@@ -415,13 +469,31 @@ if(s===r.length)return r.apply(null,b)
 return r(b)},
 v4(a,b,c,d,e,f){var s=b?"m":"",r=c?"":"i",q=d?"u":"",p=e?"s":"",o=function(g,h){try{return new RegExp(g,h)}catch(n){return n}}(a,s+r+q+p+f)
 if(o instanceof RegExp)return o
-throw A.L(A.rr("Illegal RegExp pattern ("+String(o)+")",a,null))},
+throw A.u(A.rr("Illegal RegExp pattern ("+String(o)+")",a,null))},
 m2(a,b,c){var s=a.indexOf(b,c)
 return s>=0},
-S0:function S0(a,b){this.a=a
-this.b=b},
+eA(a){if(/[[\]{}()*+?.\\^$|]/.test(a))return a.replace(/[[\]{}()*+?.\\^$|]/g,"\\$&")
+return a},
 rY:function rY(){},
-t:function t(){},
+Zr:function Zr(a,b,c,d,e,f){var _=this
+_.a=a
+_.b=b
+_.c=c
+_.d=d
+_.e=e
+_.f=f},
+W0:function W0(){},
+az:function az(a,b,c){this.a=a
+this.b=b
+this.c=c},
+vV:function vV(a){this.a=a},
+te:function te(a){this.a=a},
+bq:function bq(a,b){this.a=a
+this.b=b},
+XO:function XO(a){this.a=a
+this.b=null},
+n:function n(){},
+Ay:function Ay(){},
 E1:function E1(){},
 lc:function lc(){},
 zx:function zx(){},
@@ -433,30 +505,26 @@ _.a=0
 _.f=_.e=_.d=_.c=_.b=null
 _.r=0
 _.$ti=a},
-vh:function vh(a,b){var _=this
-_.a=a
-_.b=b
-_.d=_.c=null},
-Gp:function Gp(a,b){this.a=a
-this.$ti=b},
-N6:function N6(a,b,c){var _=this
-_.a=a
-_.b=b
-_.c=c
-_.d=null},
+db:function db(a,b){this.a=a
+this.b=b
+this.c=null},
 dC:function dC(a){this.a=a},
 wN:function wN(a){this.a=a},
 VX:function VX(a){this.a=a},
-M:function M(){},
-B7:function B7(){},
 VR:function VR(a,b){var _=this
 _.a=a
 _.b=b
 _.e=_.d=_.c=null},
+pR(a){throw A.r(A.G(a),new Error())},
+Q4(){throw A.r(A.la(""),new Error())},
+kL(){throw A.r(A.G(""),new Error())},
+wX(){var s=new A.dQ()
+return s.b=s},
+dQ:function dQ(){this.b=null},
 rM(a,b,c){var s
 if(!(a>>>0!==a))s=b>>>0!==b||a>b||b>c
 else s=!0
-if(s)throw A.L(A.au(a,b,c))
+if(s)throw A.u(A.au(a,b,c))
 return b},
 WZ:function WZ(){},
 eH:function eH(){},
@@ -465,7 +533,7 @@ b0:function b0(){},
 Dg:function Dg(){},
 DV:function DV(){},
 zU:function zU(){},
-K8:function K8(){},
+fS:function fS(){},
 xj:function xj(){},
 dE:function dE(){},
 Zc:function Zc(){},
@@ -476,7 +544,7 @@ V6:function V6(){},
 RG:function RG(){},
 vX:function vX(){},
 WB:function WB(){},
-VS:function VS(){},
+ZG:function ZG(){},
 xZ(a,b){var s=b.c
 return s==null?b.c=A.Q2(a,"b8",[b.x]):s},
 Q1(a){var s=a.w
@@ -527,7 +595,7 @@ if(b<a4)return a2
 a=a3[b-a4]
 if(a==null)return a2
 return a
-default:throw A.L(A.hV("Attempted to substitute unexpected RTI kind "+a0))}},
+default:throw A.u(A.hV("Attempted to substitute unexpected RTI kind "+a0))}},
 bZ(a,b,c,d){var s,r,q,p,o=b.length,n=A.vU(o)
 for(s=!1,r=0;r<o;++r){q=b[r]
 p=A.PL(a,q,c,d)
@@ -547,18 +615,18 @@ s.a=q
 s.b=o
 s.c=m
 return s},
-j(a,b){a[v.arrayRti]=b
+J(a,b){a[v.arrayRti]=b
 return a},
 JS(a){var s=a.$S
 if(s!=null){if(typeof s=="number")return A.Bp(s)
 return a.$S()}return null},
 Ue(a,b){var s
-if(A.Q1(b))if(a instanceof A.t){s=A.JS(a)
+if(A.Q1(b))if(a instanceof A.n){s=A.JS(a)
 if(s!=null)return s}return A.z(a)},
-z(a){if(a instanceof A.a)return A.Lh(a)
-if(Array.isArray(a))return A.t6(a)
-return A.VU(J.c(a))},
-t6(a){var s=a[v.arrayRti],r=t.b
+z(a){if(a instanceof A.Mh)return A.Lh(a)
+if(Array.isArray(a))return A.c(a)
+return A.VU(J.ia(a))},
+c(a){var s=a[v.arrayRti],r=t.b
 if(s==null)return r
 if(s.constructor!==r.constructor)return r
 return s},
@@ -567,7 +635,7 @@ return s!=null?s:A.VU(a)},
 VU(a){var s=a.constructor,r=s.$ccache
 if(r!=null)return r
 return A.r9(a,s)},
-r9(a,b){var s=a instanceof A.t?Object.getPrototypeOf(Object.getPrototypeOf(a)).constructor:b,r=A.ai(v.typeUniverse,s.name)
+r9(a,b){var s=a instanceof A.n?Object.getPrototypeOf(Object.getPrototypeOf(a)).constructor:b,r=A.ai(v.typeUniverse,s.name)
 b.$ccache=r
 return r},
 Bp(a){var s,r=v.types,q=r[a]
@@ -575,20 +643,13 @@ if(typeof q=="string"){s=A.Ew(v.typeUniverse,q,!1)
 r[a]=s
 return s}return q},
 RW(a){return A.Kx(A.Lh(a))},
-tu(a){var s
-if(a instanceof A.M)return A.Mi(a.$r,a.n())
-s=a instanceof A.t?A.JS(a):null
+tu(a){var s=a instanceof A.n?A.JS(a):null
 if(s!=null)return s
 if(t.R.b(a))return J.CR(a).a
-if(Array.isArray(a))return A.t6(a)
+if(Array.isArray(a))return A.c(a)
 return A.z(a)},
 Kx(a){var s=a.r
 return s==null?a.r=new A.lY(a):s},
-Mi(a,b){var s,r,q=b,p=q.length
-if(p===0)return t.F
-s=A.cE(v.typeUniverse,A.tu(q[0]),"@<0>")
-for(r=1;r<p;++r)s=A.v5(v.typeUniverse,s,A.tu(q[r]))
-return A.cE(v.typeUniverse,s,a)},
 xq(a){return A.Kx(A.Ew(v.typeUniverse,a,!1))},
 JJ(a){var s=this
 s.b=A.fr(s)
@@ -611,7 +672,7 @@ return p==null?A.JY:p}return A.YO},
 U5(a){if(a.w===8){if(a===t.S)return A.ok
 if(a===t.i||a===t.H)return A.KH
 if(a===t.N)return A.MM
-if(a===t.y)return A.y}return null},
+if(a===t.y)return A.L}return null},
 Au(a){var s=this,r=A.Oz
 if(A.cc(s))r=A.hn
 else if(s===t.K)r=A.Ti
@@ -619,12 +680,14 @@ else if(A.lR(s)){r=A.l4
 if(s===t.x)r=A.Uc
 else if(s===t.w)r=A.ra
 else if(s===t.u)r=A.M4
-else if(s===t.n)r=A.cU
-else if(s===t.I)r=A.Qk}else if(s===t.S)r=A.IZ
+else if(s===t.B)r=A.cU
+else if(s===t.I)r=A.Qk
+else if(s===t.A)r=A.wI}else if(s===t.S)r=A.IZ
 else if(s===t.N)r=A.Bt
 else if(s===t.y)r=A.p8
 else if(s===t.H)r=A.z5
 else if(s===t.i)r=A.rV
+else if(s===t.m)r=A.A
 s.a=r
 return s.a(a)},
 YO(a){var s=this
@@ -635,18 +698,21 @@ return this.x.b(a)},
 t4(a){var s,r=this
 if(a==null)return A.lR(r)
 s=r.f
-if(a instanceof A.a)return!!a[s]
-return!!J.c(a)[s]},
+if(a instanceof A.Mh)return!!a[s]
+return!!J.ia(a)[s]},
 yM(a){var s,r=this
 if(a==null)return A.lR(r)
 if(typeof a!="object")return!1
 if(Array.isArray(a))return!0
 s=r.f
-if(a instanceof A.a)return!!a[s]
-return!!J.c(a)[s]},
+if(a instanceof A.Mh)return!!a[s]
+return!!J.ia(a)[s]},
 xD(a){var s=this
 if(a==null)return!1
-if(typeof a=="object"){if(a instanceof A.a)return!!a[s.f]
+if(typeof a=="object"){if(a instanceof A.Mh)return!!a[s.f]
+return!0}if(typeof a=="function")return!0
+return!1},
+Vl(a){if(typeof a=="object"){if(a instanceof A.Mh)return t.m.b(a)
 return!0}if(typeof a=="function")return!0
 return!1},
 Oz(a){var s=this
@@ -655,8 +721,8 @@ throw A.r(A.fT(a,s),new Error())},
 l4(a){var s=this
 if(a==null||s.b(a))return a
 throw A.r(A.fT(a,s),new Error())},
-fT(a,b){return new A.iM("TypeError: "+A.WK(a,A.d(b,null)))},
-WK(a,b){return A.h(a)+": type '"+A.d(A.tu(a),null)+"' is not a subtype of type '"+b+"'"},
+fT(a,b){return new A.iM("TypeError: "+A.WK(a,A.dm(b,null)))},
+WK(a,b){return A.h(a)+": type '"+A.dm(A.tu(a),null)+"' is not a subtype of type '"+b+"'"},
 Lz(a,b){return new A.iM("TypeError: "+A.WK(a,b))},
 fg(a){var s=this
 return s.x.b(a)||A.xZ(v.typeUniverse,s).b(a)},
@@ -666,7 +732,7 @@ throw A.r(A.Lz(a,"Object"),new Error())},
 Iw(a){return!0},
 hn(a){return a},
 JY(a){return!1},
-y(a){return!0===a||!1===a},
+L(a){return!0===a||!1===a},
 p8(a){if(!0===a)return!0
 if(!1===a)return!1
 throw A.r(A.Lz(a,"bool"),new Error())},
@@ -697,28 +763,33 @@ throw A.r(A.Lz(a,"String"),new Error())},
 ra(a){if(typeof a=="string")return a
 if(a==null)return a
 throw A.r(A.Lz(a,"String?"),new Error())},
-m(a,b){var s,r,q
-for(s="",r="",q=0;q<a.length;++q,r=", ")s+=r+A.d(a[q],b)
+A(a){if(A.Vl(a))return a
+throw A.r(A.Lz(a,"JSObject"),new Error())},
+wI(a){if(a==null)return a
+if(A.Vl(a))return a
+throw A.r(A.Lz(a,"JSObject?"),new Error())},
+io(a,b){var s,r,q
+for(s="",r="",q=0;q<a.length;++q,r=", ")s+=r+A.dm(a[q],b)
 return s},
-k(a,b){var s,r,q,p,o,n,m=a.x,l=a.y
-if(""===m)return"("+A.m(l,b)+")"
+wT(a,b){var s,r,q,p,o,n,m=a.x,l=a.y
+if(""===m)return"("+A.io(l,b)+")"
 s=l.length
 r=m.split(",")
 q=r.length-s
 for(p="(",o="",n=0;n<s;++n,o=", "){p+=o
 if(q===0)p+="{"
-p+=A.d(l[n],b)
+p+=A.dm(l[n],b)
 if(q>=0)p+=" "+r[q];++q}return p+"})"},
-b(a1,a2,a3){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a=", ",a0=null
+bI(a1,a2,a3){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a=", ",a0=null
 if(a3!=null){s=a3.length
-if(a2==null)a2=A.j([],t.s)
+if(a2==null)a2=A.J([],t.s)
 else a0=a2.length
 r=a2.length
 for(q=s;q>0;--q)a2.push("T"+(r+q))
 for(p=t.X,o="<",n="",q=0;q<s;++q,n=a){o=o+n+a2[a2.length-1-q]
 m=a3[q]
 l=m.w
-if(!(l===2||l===3||l===4||l===5||m===p))o+=" extends "+A.d(m,a2)}o+=">"}else o=""
+if(!(l===2||l===3||l===4||l===5||m===p))o+=" extends "+A.dm(m,a2)}o+=">"}else o=""
 p=a1.x
 k=a1.y
 j=k.a
@@ -727,33 +798,33 @@ h=k.b
 g=h.length
 f=k.c
 e=f.length
-d=A.d(p,a2)
-for(c="",b="",q=0;q<i;++q,b=a)c+=b+A.d(j[q],a2)
+d=A.dm(p,a2)
+for(c="",b="",q=0;q<i;++q,b=a)c+=b+A.dm(j[q],a2)
 if(g>0){c+=b+"["
-for(b="",q=0;q<g;++q,b=a)c+=b+A.d(h[q],a2)
+for(b="",q=0;q<g;++q,b=a)c+=b+A.dm(h[q],a2)
 c+="]"}if(e>0){c+=b+"{"
 for(b="",q=0;q<e;q+=3,b=a){c+=b
 if(f[q+1])c+="required "
-c+=A.d(f[q+2],a2)+" "+f[q]}c+="}"}if(a0!=null){a2.toString
+c+=A.dm(f[q+2],a2)+" "+f[q]}c+="}"}if(a0!=null){a2.toString
 a2.length=a0}return o+"("+c+") => "+d},
-d(a,b){var s,r,q,p,o,n,m=a.w
+dm(a,b){var s,r,q,p,o,n,m=a.w
 if(m===5)return"erased"
 if(m===2)return"dynamic"
 if(m===3)return"void"
 if(m===1)return"Never"
 if(m===4)return"any"
 if(m===6){s=a.x
-r=A.d(s,b)
+r=A.dm(s,b)
 q=s.w
-return(q===11||q===12?"("+r+")":r)+"?"}if(m===7)return"FutureOr<"+A.d(a.x,b)+">"
-if(m===8){p=A.o(a.x)
+return(q===11||q===12?"("+r+")":r)+"?"}if(m===7)return"FutureOr<"+A.dm(a.x,b)+">"
+if(m===8){p=A.o3(a.x)
 o=a.y
-return o.length>0?p+("<"+A.m(o,b)+">"):p}if(m===10)return A.k(a,b)
-if(m===11)return A.b(a,b,null)
-if(m===12)return A.b(a.x,b,a.y)
+return o.length>0?p+("<"+A.io(o,b)+">"):p}if(m===10)return A.wT(a,b)
+if(m===11)return A.bI(a,b,null)
+if(m===12)return A.bI(a.x,b,a.y)
 if(m===13){n=a.x
 return b[b.length-1-n]}return"?"},
-o(a){var s=v.mangledGlobalNames[a]
+o3(a){var s=v.mangledGlobalNames[a]
 if(s!=null)return s
 return"minified:"+a},
 Qo(a,b){var s=a.tR[b]
@@ -775,7 +846,7 @@ if(q!=null)return q
 s=A.eT(A.ow(a,null,b,!1))
 r.set(b,s)
 return s},
-cE(a,b,c){var s,r,q=b.z
+B(a,b,c){var s,r,q=b.z
 if(q==null)q=b.z=new Map()
 s=q.get(c)
 if(s!=null)return s
@@ -825,7 +896,7 @@ eV(a,b,c,d){var s,r
 if(d){s=b.w
 if(A.cc(b)||b===t.K)return b
 else if(s===1)return A.Q2(a,"b8",[b])
-else if(b===t.P||b===t.T)return t.W}r=new A.Jc(null,null)
+else if(b===t.P||b===t.T)return t.O}r=new A.Jc(null,null)
 r.w=7
 r.x=b
 r.as=c
@@ -997,8 +1068,8 @@ if(e){s=a.u
 o=a.e
 if(o.w===9)o=o.x
 n=A.Qo(s,o.x)[p]
-if(n==null)A.v('No "'+p+'" in "'+A.mD(o)+'"')
-d.push(A.cE(s,o,n))}else d.push(p)
+if(n==null)A.vh('No "'+p+'" in "'+A.mD(o)+'"')
+d.push(A.B(s,o,n))}else d.push(p)
 return m},
 rD(a,b){var s,r=a.u,q=A.oU(a,b),p=b.pop()
 if(typeof p=="string")b.push(A.Q2(r,p,q))
@@ -1028,11 +1099,11 @@ b.push(A.Nf(p,r,q))
 return
 case-4:b.push(A.oP(p,b.pop(),s))
 return
-default:throw A.L(A.hV("Unexpected state under `()`: "+A.I(o)))}},
+default:throw A.u(A.hV("Unexpected state under `()`: "+A.d(o)))}},
 I3(a,b){var s=b.pop()
 if(0===s){b.push(A.mZ(a.u,1,"0&"))
 return}if(1===s){b.push(A.mZ(a.u,4,"1&"))
-return}throw A.L(A.hV("Unexpected extended operation "+A.I(s)))},
+return}throw A.u(A.hV("Unexpected extended operation "+A.d(s)))},
 oU(a,b){var s=b.splice(a.p)
 A.cH(a.u,a.e,s)
 a.p=b.pop()
@@ -1052,10 +1123,10 @@ if(c<=r)return s[c-1]
 c-=r
 b=b.x
 q=b.w}else if(c===0)return b
-if(q!==8)throw A.L(A.hV("Indexed base must be an interface type"))
+if(q!==8)throw A.u(A.hV("Indexed base must be an interface type"))
 s=b.y
 if(c<=s.length)return s[c-1]
-throw A.L(A.hV("Bad index "+c+" for "+b["["](0)))},
+throw A.u(A.hV("Bad index "+c+" for "+b["["](0)))},
 t1(a,b,c){var s,r=b.d
 if(r==null)r=b.d=new Map()
 s=r.get(c)
@@ -1141,7 +1212,7 @@ continue}r=s[m]
 if(r==null)return!1
 q=r.length
 p=q>0?new Array(q):v.typeUniverse.sEA
-for(o=0;o<q;++o)p[o]=A.cE(a,b,r[o])
+for(o=0;o<q;++o)p[o]=A.B(a,b,r[o])
 return A.SW(a,p,null,c,d.y,e)}return A.SW(a,b.y,null,c,d.y,e)},
 SW(a,b,c,d,e,f){var s,r=b.length
 for(s=0;s<r;++s)if(!A.We(a,b[s],d,e[s],f))return!1
@@ -1170,45 +1241,274 @@ ET:function ET(){this.c=this.b=this.a=null},
 lY:function lY(a){this.a=a},
 u9:function u9(){},
 iM:function iM(a){this.a=a},
-vL(a,b){var s=a[b]
-return s===a?null:s},
-a8(a,b,c){if(c==null)a[b]=a
-else a[b]=c},
-a0(){var s=Object.create(null)
-A.a8(s,"<non-identifier-key>",s)
-delete s["<non-identifier-key>"]
+xg(){var s,r,q
+if(self.scheduleImmediate!=null)return A.EX()
+if(self.MutationObserver!=null&&self.document!=null){s={}
+r=self.document.createElement("div")
+q=self.document.createElement("span")
+s.a=null
+new self.MutationObserver(A.tR(new A.th(s),1)).observe(r,{childList:true})
+return new A.ha(s,r,q)}else if(self.setImmediate!=null)return A.yt()
+return A.qW()},
+ZV(a){self.scheduleImmediate(A.tR(new A.Vs(a),0))},
+oA(a){self.setImmediate(A.tR(new A.Ft(a),0))},
+Bz(a){A.QN(0,a)},
+QN(a,b){var s=new A.W3()
+s.P(a,b)
 return s},
-EF(a,b,c){return A.dJ(a,new A.N5(b.C("@<0>").Kq(c).C("N5<1,2>")))},
-C(a,b){return new A.N5(a.C("@<0>").Kq(b).C("N5<1,2>"))},
+F(a){return new A.ih(new A.vs($.X3,a.C("vs<0>")),a.C("ih<0>"))},
+D(a,b){a.$2(0,null)
+b.b=!0
+return b.a},
+j(a,b){A.Je(a,b)},
+y(a,b){b.j(a)},
+x(a,b){b.k(A.Ru(a),A.ts(a))},
+Je(a,b){var s,r,q=new A.WM(b),p=new A.SX(b)
+if(a instanceof A.vs)a.h(q,p,t.z)
+else{s=t.z
+if(a instanceof A.vs)a.S(q,p,s)
+else{r=new A.vs($.X3,t.c)
+r.a=8
+r.c=a
+r.h(q,p,s)}}},
+l(a){var s=function(b,c){return function(d,e){while(true){try{b(d,e)
+break}catch(r){e=r
+d=c}}}}(a,1)
+return $.X3.O(new A.Gs(s))},
+v0(a){var s
+if(t.C.b(a)){s=a.gn()
+if(s!=null)return s}return B.pd},
+v(a,b){var s,r,q,p=A.J([],b.C("jd<ru<0>>"))
+for(s=a.length,r=b.C("ru<0>"),q=0;q<a.length;a.length===s||(0,A.q)(a),++q)p.push(new A.ru(a[q],r))
+if(p.length===0){p=A.J([],b.C("jd<0>"))
+s=new A.vs($.X3,b.C("vs<zM<0>>"))
+s.D(p)
+return s}s=new A.vs($.X3,b.C("vs<zM<0>>"))
+A.F1(p,new A.fs(new A.mJ(s,b.C("mJ<zM<0>>")),p,b))
+return s},
+tC(a){return a!=null},
+F1(a,b){var s,r={},q=r.a=r.b=0,p=new A.Xk(r,a,b)
+for(s=a.length;q<a.length;a.length===s||(0,A.q)(a),++q)a[q].v(p)},
+vS(a,b){if($.X3===B.NU)return null
+return null},
+ux(a,b){if($.X3!==B.NU)A.vS(a,b)
+if(b==null)if(t.C.b(a)){b=a.gn()
+if(b==null){A.mj(a,B.pd)
+b=B.pd}}else b=B.pd
+else if(t.C.b(a))A.mj(a,b)
+return new A.OH(a,b)},
+A9(a,b,c){var s,r,q,p={},o=p.a=a
+for(;s=o.a,(s&4)!==0;){o=o.c
+p.a=o}if(o===b){s=A.Zb()
+b.i(new A.OH(new A.AT(!0,o,null,"Cannot complete a future with itself"),s))
+return}r=b.a&1
+s=o.a=s|r
+if((s&24)===0){q=b.c
+b.a=b.a&1|4
+b.c=o
+o.T(q)
+return}if(!c)if(b.c==null)o=(s&16)===0||r!==0
+else o=!1
+else o=!0
+if(o){q=b.I()
+b.V(p.a)
+A.HZ(b,q)
+return}b.a^=2
+A.Tk(null,null,b.b,new A.fG(p,b))},
+HZ(a,b){var s,r,q,p,o,n,m,l,k,j,i,h,g={},f=g.a=a
+for(;!0;){s={}
+r=f.a
+q=(r&16)===0
+p=!q
+if(b==null){if(p&&(r&1)===0){f=f.c
+A.Si(f.a,f.b)}return}s.a=b
+o=b.a
+for(f=b;o!=null;f=o,o=n){f.a=null
+A.HZ(g.a,f)
+s.a=o
+n=o.a}r=g.a
+m=r.c
+s.b=p
+s.c=m
+if(q){l=f.c
+l=(l&1)!==0||(l&15)===8}else l=!0
+if(l){k=f.b.b
+if(p){r=r.b===k
+r=!(r||r)}else r=!1
+if(r){A.Si(m.a,m.b)
+return}j=$.X3
+if(j!==k)$.X3=k
+else j=null
+f=f.c
+if((f&15)===8)new A.RT(s,g,p).$0()
+else if(q){if((f&1)!==0)new A.rq(s,m).$0()}else if((f&2)!==0)new A.vQ(g,s).$0()
+if(j!=null)$.X3=j
+f=s.c
+if(f instanceof A.vs){r=s.a.$ti
+r=r.C("b8<2>").b(f)||!r.y[1].b(f)}else r=!1
+if(r){i=s.a.b
+if((f.a&24)!==0){h=i.c
+i.c=null
+b=i.J(h)
+i.a=f.a&30|i.a&1
+i.c=f.c
+g.a=f
+continue}else A.A9(f,i,!0)
+return}}i=s.a.b
+h=i.c
+i.c=null
+b=i.J(h)
+f=s.b
+r=s.c
+if(!f){i.a=8
+i.c=r}else{i.a=i.a&1|16
+i.c=r}g.a=i
+f=i}},
+VH(a,b){if(t.Q.b(a))return b.O(a)
+if(t.v.b(a))return a
+throw A.u(A.L3(a,"onError",u.c))},
+pu(){var s,r
+for(s=$.S6;s!=null;s=$.S6){$.mg=null
+r=s.b
+$.S6=r
+if(r==null)$.k8=null
+s.a.$0()}},
+eN(){$.UD=!0
+try{A.pu()}finally{$.mg=null
+$.UD=!1
+if($.S6!=null)$.ut().$1(A.UI())}},
+IA(a){var s=new A.OM(a),r=$.k8
+if(r==null){$.S6=$.k8=s
+if(!$.UD)$.ut().$1(A.UI())}else $.k8=r.b=s},
+rR(a){var s,r,q,p=$.S6
+if(p==null){A.IA(a)
+$.mg=$.k8
+return}s=new A.OM(a)
+r=$.mg
+if(r==null){s.b=p
+$.S6=$.mg=s}else{q=r.b
+s.b=q
+$.mg=r.b=s
+if(q==null)$.k8=s}},
+Qw(a){A.cb(a,"stream",t.K)
+return new A.xI()},
+Si(a,b){A.rR(new A.Ev(a,b))},
+T8(a,b,c,d){var s,r=$.X3
+if(r===c)return d.$0()
+$.X3=c
+s=r
+try{r=d.$0()
+return r}finally{$.X3=s}},
+yv(a,b,c,d,e){var s,r=$.X3
+if(r===c)return d.$1(e)
+$.X3=c
+s=r
+try{r=d.$1(e)
+return r}finally{$.X3=s}},
+Qx(a,b,c,d,e,f){var s,r=$.X3
+if(r===c)return d.$2(e,f)
+$.X3=c
+s=r
+try{r=d.$2(e,f)
+return r}finally{$.X3=s}},
+Tk(a,b,c,d){if(B.NU!==c){d=c.t(d)
+d=d}A.IA(d)},
+th:function th(a){this.a=a},
+ha:function ha(a,b,c){this.a=a
+this.b=b
+this.c=c},
+Vs:function Vs(a){this.a=a},
+Ft:function Ft(a){this.a=a},
+W3:function W3(){},
+yH:function yH(a,b){this.a=a
+this.b=b},
+ih:function ih(a,b){this.a=a
+this.b=!1
+this.$ti=b},
+WM:function WM(a){this.a=a},
+SX:function SX(a){this.a=a},
+Gs:function Gs(a){this.a=a},
+OH:function OH(a,b){this.a=a
+this.b=b},
+fs:function fs(a,b,c){this.a=a
+this.b=b
+this.c=c},
+uH:function uH(a,b){this.c=a
+this.d=b},
+ru:function ru(a,b){var _=this
+_.a=a
+_.c=_.b=null
+_.$ti=b},
+ey:function ey(a,b){this.a=a
+this.b=b},
+TM:function TM(a,b){this.a=a
+this.b=b},
+Xk:function Xk(a,b,c){this.a=a
+this.b=b
+this.c=c},
+Pf:function Pf(){},
+Zf:function Zf(a,b){this.a=a
+this.$ti=b},
+mJ:function mJ(a,b){this.a=a
+this.$ti=b},
+Fe:function Fe(a,b,c,d,e){var _=this
+_.a=null
+_.b=a
+_.c=b
+_.d=c
+_.e=d
+_.$ti=e},
+vs:function vs(a,b){var _=this
+_.a=0
+_.b=a
+_.c=null
+_.$ti=b},
+da:function da(a,b){this.a=a
+this.b=b},
+oQ:function oQ(a,b){this.a=a
+this.b=b},
+fG:function fG(a,b){this.a=a
+this.b=b},
+rt:function rt(a,b){this.a=a
+this.b=b},
+xR:function xR(a,b){this.a=a
+this.b=b},
+RT:function RT(a,b,c){this.a=a
+this.b=b
+this.c=c},
+jZ:function jZ(a,b){this.a=a
+this.b=b},
+FZ:function FZ(a){this.a=a},
+rq:function rq(a,b){this.a=a
+this.b=b},
+vQ:function vQ(a,b){this.a=a
+this.b=b},
+OM:function OM(a){this.a=a
+this.b=null},
+xI:function xI(){},
+m0:function m0(){},
+Ev:function Ev(a,b){this.a=a
+this.b=b},
+Ji:function Ji(){},
+Vp:function Vp(a,b){this.a=a
+this.b=b},
+Fl(a,b){return new A.N5(a.C("@<0>").K(b).C("N5<1,2>"))},
 nO(a){var s,r
-if(A.ks(a))return"{...}"
-s=new A.Rn("")
+if(A.o(a))return"{...}"
+s=new A.M("")
 try{r={}
-$.Qu.push(a)
+$.p.push(a)
 s.a+="{"
 r.a=!0
-a.aN(0,new A.mN(r,s))
-s.a+="}"}finally{$.Qu.pop()}r=s.a
+a.aN(0,new A.GA(r,s))
+s.a+="}"}finally{$.p.pop()}r=s.a
 return r.charCodeAt(0)==0?r:r},
-k6:function k6(){},
-YF:function YF(a){var _=this
-_.a=0
-_.e=_.d=_.c=_.b=null
-_.$ti=a},
-Ni:function Ni(a,b){this.a=a
-this.$ti=b},
-t3:function t3(a,b,c){var _=this
-_.a=a
-_.b=b
-_.c=0
-_.d=null
-_.$ti=c},
-F:function F(){},
+ar:function ar(){},
 il:function il(){},
-mN:function mN(a,b){this.a=a
+GA:function GA(a,b){this.a=a
 this.b=b},
 Uk:function Uk(){},
-wI:function wI(){},
+zF:function zF(){},
 Zi:function Zi(){},
 u5:function u5(){},
 E3:function E3(){},
@@ -1216,18 +1516,17 @@ Rw:function Rw(a){this.b=0
 this.c=a},
 QA(a,b){var s=A.Hp(a,b)
 if(s!=null)return s
-throw A.L(A.rr(a,null,null))},
+throw A.u(A.rr(a,null,null))},
+O1(a,b){a=A.r(a,new Error())
+a.stack=b["["](0)
+throw a},
 O8(a,b,c){var s,r,q
-if(a<0||a>4294967295)A.v(A.TE(a,0,4294967295,"length",null))
-s=A.j(new Array(a),c.C("p<0>"))
+if(a>4294967295)A.vh(A.TE(a,0,4294967295,"length",null))
+s=A.J(new Array(a),c.C("jd<0>"))
 s.$flags=1
 r=s
-if(a!==0&&b!=null)for(q=0;q<r.length;++q)r[q]=b
+if(a!==0)for(s=r.length,q=0;q<s;++q)r[q]=b
 return r},
-PW(a,b,c){var s,r,q=A.j([],c.C("p<0>"))
-for(s=a.length,r=0;r<a.length;a.length===s||(0,A.lk)(a),++r)q.push(a[r])
-q.$flags=1
-return q},
 HM(a){var s
 A.k1(0,"start")
 s=A.Nz(a,0,null)
@@ -1236,18 +1535,18 @@ Nz(a,b,c){var s=a.length
 if(b>=s)return""
 return A.fw(a,b,s)},
 nu(a){return new A.VR(a,A.v4(a,!1,!0,!1,!1,""))},
-vg(a,b,c){var s=J.IT(b)
+H(a,b,c){var s=J.I(b)
 if(!s.G())return a
-if(c.length===0){do a+=A.I(s.gl())
-while(s.G())}else{a+=A.I(s.gl())
-for(;s.G();)a=a+c+A.I(s.gl())}return a},
+if(c.length===0){do a+=A.d(s.gl())
+while(s.G())}else{a+=A.d(s.gl())
+for(;s.G();)a=a+c+A.d(s.gl())}return a},
 eP(a,b,c,d){var s,r,q,p,o,n="0123456789ABCDEF"
 if(c===B.xM){s=$.z4()
 s=s.b.test(b)}else s=!1
 if(s)return b
-r=B.Qk.W(b)
+r=B.Qk.WJ(b)
 for(s=r.length,q=0,p="";q<s;++q){o=r[q]
-if(o<128&&(u.b.charCodeAt(o)&a)!==0)p+=A.Lw(o)
+if(o<128&&(u.f.charCodeAt(o)&a)!==0)p+=A.Lw(o)
 else p=d&&o===32?p+"+":p+"%"+n[o>>>4&15]+n[o&15]}return p.charCodeAt(0)==0?p:p},
 tS(a){var s,r,q
 if(!$.Ob())return A.yf(a)
@@ -1257,72 +1556,35 @@ r=s.toString()
 q=r.length
 if(q>0&&r[q-1]==="=")r=B.xB.Nj(r,0,q-1)
 return r.replace(/=&|\*|%7E/g,b=>b==="=&"?"&":b==="*"?"%2A":"~")},
-h(a){if(typeof a=="number"||A.y(a)||a==null)return J.n(a)
+Zb(){return A.ts(new Error())},
+h(a){if(typeof a=="number"||A.L(a)||a==null)return J.C(a)
 if(typeof a=="string")return JSON.stringify(a)
 return A.i(a)},
+kM(a,b){A.cb(a,"error",t.K)
+A.cb(b,"stackTrace",t.l)
+A.O1(a,b)},
 hV(a){return new A.C6(a)},
-q(a){return new A.AT(!1,null,null,a)},
+xY(a,b){return new A.AT(!1,null,b,a)},
+L3(a,b,c){return new A.AT(!0,a,b,c)},
 TE(a,b,c,d,e){return new A.bJ(b,c,!0,a,d,"Invalid value")},
-jB(a,b,c){if(0>a||a>c)throw A.L(A.TE(a,0,c,"start",null))
-if(b!=null){if(a>b||b>c)throw A.L(A.TE(b,a,c,"end",null))
+jB(a,b,c){if(0>a||a>c)throw A.u(A.TE(a,0,c,"start",null))
+if(b!=null){if(a>b||b>c)throw A.u(A.TE(b,a,c,"end",null))
 return b}return c},
-k1(a,b){if(a<0)throw A.L(A.TE(a,0,null,b,null))
+k1(a,b){if(a<0)throw A.u(A.TE(a,0,null,b,null))
 return a},
-xF(a,b,c,d){return new A.eY(b,!0,a,d,"Index out of range")},
+u0(a){return new A.ub(a)},
 SY(a){return new A.ds(a)},
-a4(a){return new A.UV(a)},
+PV(a){return new A.lj(a)},
+a(a){return new A.UV(a)},
 rr(a,b,c){return new A.aE(a,b,c)},
-Sd(a,b,c){var s,r
-if(A.ks(a)){if(b==="("&&c===")")return"(...)"
-return b+"..."+c}s=A.j([],t.s)
-$.Qu.push(a)
-try{A.Vr(a,s)}finally{$.Qu.pop()}r=A.vg(b,s,", ")+c
-return r.charCodeAt(0)==0?r:r},
-x(a,b,c){var s,r
-if(A.ks(a))return b+"..."+c
-s=new A.Rn(b)
-$.Qu.push(a)
+k(a,b,c){var s,r
+if(A.o(a))return b+"..."+c
+s=new A.M(b)
+$.p.push(a)
 try{r=s
-r.a=A.vg(r.a,a,", ")}finally{$.Qu.pop()}s.a+=c
+r.a=A.H(r.a,a,", ")}finally{$.p.pop()}s.a+=c
 r=s.a
 return r.charCodeAt(0)==0?r:r},
-Vr(a,b){var s,r,q,p,o,n,m,l=a.gkz(a),k=0,j=0
-while(!0){if(!(k<80||j<3))break
-if(!l.G())return
-s=A.I(l.gl())
-b.push(s)
-k+=s.length+2;++j}if(!l.G()){if(j<=5)return
-r=b.pop()
-q=b.pop()}else{p=l.gl();++j
-if(!l.G()){if(j<=4){b.push(A.I(p))
-return}r=A.I(p)
-q=b.pop()
-k+=r.length+2}else{o=l.gl();++j
-for(;l.G();p=o,o=n){n=l.gl();++j
-if(j>100){while(!0){if(!(k>75&&j>3))break
-k-=b.pop().length+2;--j}b.push("...")
-return}}q=A.I(p)
-r=A.I(o)
-k+=r.length+q.length+4}}if(j>b.length+2){k+=5
-m="..."}else m=null
-while(!0){if(!(k>80&&b.length>3))break
-k-=b.pop().length+2
-if(m==null){k+=5
-m="..."}}if(m!=null)b.push(m)
-b.push(q)
-b.push(r)},
-f5(a,b,c,d){var s
-if(B.zt===c){s=B.jn.gi(a)
-b=J.Nu(b)
-return A.qL(A.yc(A.yc($.t8(),s),b))}if(B.zt===d){s=B.jn.gi(a)
-b=J.Nu(b)
-c=J.Nu(c)
-return A.qL(A.yc(A.yc(A.yc($.t8(),s),b),c))}s=B.jn.gi(a)
-b=J.Nu(b)
-c=J.Nu(c)
-d=J.Nu(d)
-d=A.qL(A.yc(A.yc(A.yc(A.yc($.t8(),s),b),c),d))
-return d},
 Hh(a,b,c){var s,r,q,p,o,n,m="IPv4 address should contain exactly 4 parts",l="each part must be in the range 0..255",k=new A.cS(a),j=new Uint8Array(4)
 for(s=b,r=s,q=0;s<c;++s){p=a.charCodeAt(s)
 if(p!==46){if((p^48)>9)k.$2("invalid character",s)}else{if(q===3)k.$2(m,s)
@@ -1337,9 +1599,9 @@ if(o>255)k.$2(l,r)
 j[q]=o
 return j},
 Xh(a,b,c){var s
-if(b===c)throw A.L(A.rr("Empty IP address",a,b))
+if(b===c)throw A.u(A.rr("Empty IP address",a,b))
 if(a.charCodeAt(b)===118){s=A.lN(a,b,c)
-if(s!=null)throw A.L(s)
+if(s!=null)throw A.u(s)
 return!1}A.eg(a,b,c)
 return!0},
 lN(a,b,c){var s,r,q,p,o="Missing hex-digit in IPvFuture address";++b
@@ -1352,12 +1614,12 @@ if(q===46){if(r-1===b)return new A.aE(o,a,r)
 s=r
 break}return new A.aE("Unexpected character",a,r-1)}if(s-1===b)return new A.aE(o,a,s)
 return new A.aE("Missing '.' in IPvFuture address",a,s)}if(s===c)return new A.aE("Missing address in IPvFuture address, host, cursor",null,null)
-for(;!0;){if((u.b.charCodeAt(a.charCodeAt(s))&16)!==0){++s
+for(;!0;){if((u.f.charCodeAt(a.charCodeAt(s))&16)!==0){++s
 if(s<c)continue
 return null}return new A.aE("Invalid IPvFuture address character",a,s)}},
 eg(a,b,a0){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e=null,d=new A.VC(a),c=new A.JT(d,a)
 if(a.length<2)d.$2("address is too short",e)
-s=A.j([],t.t)
+s=A.J([],t.t)
 for(r=b,q=r,p=!1,o=!1;r<a0;++r){n=a.charCodeAt(r)
 if(n===58){if(r===b){++r
 if(a.charCodeAt(r)!==58)d.$2("invalid start colon.",r)
@@ -1366,7 +1628,7 @@ s.push(-1)
 p=!0}else s.push(c.$2(q,r))
 q=r+1}else if(n===46)o=!0}if(s.length===0)d.$2("too few parts",e)
 m=q===a0
-l=B.Nm.gV(s)
+l=B.Nm.grZ(s)
 if(m&&l!==-1)d.$2("expected a part after last `:`",a0)
 if(!m)if(!o)s.push(c.$2(q,a0))
 else{k=A.Hh(a,q,a0)
@@ -1376,50 +1638,15 @@ j=new Uint8Array(16)
 for(l=s.length,i=9-l,r=0,h=0;r<l;++r){g=s[r]
 if(g===-1)for(f=0;f<i;++f){j[h]=0
 j[h+1]=0
-h+=2}else{j[h]=B.jn.P(g,8)
+h+=2}else{j[h]=B.jn.A(g,8)
 j[h+1]=g&255
 h+=2}}return j},
-wK(a){if(a==="http")return 80
+GO(a){if(a==="http")return 80
 if(a==="https")return 443
 return 0},
-R3(a,b,c){throw A.L(A.rr(c,a,b))},
-Xd(a,a0,a1,a2){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e=null,d=a0.length,c="",b=e
-if(d!==0){r=0
-while(!0){if(!(r<d)){s=0
-break}if(a0.charCodeAt(r)===64){c=B.xB.Nj(a0,0,r)
-s=r+1
-break}++r}if(s<d&&a0.charCodeAt(s)===91){for(q=s,p=-1;q<d;++q){o=a0.charCodeAt(q)
-if(o===37&&p<0){n=B.xB.Y(a0,"25",q+1)?q+2:q
-p=q
-q=n}else if(o===93)break}if(q===d)throw A.L(A.rr("Invalid IPv6 host entry.",a0,s))
-m=p<0?q:p
-A.Xh(a0,s+1,m);++q
-if(q!==d&&a0.charCodeAt(q)!==58)throw A.L(A.rr("Invalid end of authority",a0,q))}else q=s
-for(;q<d;++q)if(a0.charCodeAt(q)===58){l=B.xB.yn(a0,q+1)
-b=l.length!==0?A.QA(l,e):e
-break}k=B.xB.Nj(a0,s,q)}else k=e
-d=A.j(a1.split("/"),t.s)
-a=A.Pi(a,0,a.length)
-c=A.zR(c,0,c.length)
-k=A.Oe(k,0,k==null?0:k.length,!1)
-j=A.le(e,0,0,a2)
-i=A.tG(e,0,0)
-b=A.wB(b,a)
-h=a==="file"
-if(k==null)m=c.length!==0||b!=null||h
-else m=!1
-if(m)k=""
-m=k==null
-g=!m
-f=A.ka(e,0,0,d,a,g)
-d=a.length===0
-if(d&&m&&!B.xB.v(f,"/"))f=A.wF(f,!d||g)
-else f=A.xe(f)
-return new A.Dn(a,c,m&&B.xB.v(f,"//")?"":k,b,f,j,i)},
-wB(a,b){if(a!=null&&a===A.wK(b))return null
-return a},
+R3(a,b,c){throw A.u(A.rr(c,a,b))},
+wB(a,b){return a},
 Oe(a,b,c,d){var s,r,q,p,o,n,m,l
-if(a==null)return null
 if(b===c)return""
 if(a.charCodeAt(b)===91){s=c-1
 if(a.charCodeAt(s)!==93)A.R3(a,b,"Missing end `]` to match `[` in host")
@@ -1427,50 +1654,50 @@ r=b+1
 q=""
 if(a.charCodeAt(r)!==118){p=A.to(a,r,s)
 if(p<s){o=p+1
-q=A.OA(a,B.xB.Y(a,"25",o)?p+3:o,s,"%25")}s=p}n=A.Xh(a,r,s)
+q=A.OA(a,B.xB.Qi(a,"25",o)?p+3:o,s,"%25")}s=p}n=A.Xh(a,r,s)
 m=B.xB.Nj(a,r,s)
-return"["+(n?m.toLowerCase():m)+q+"]"}for(l=b;l<c;++l)if(a.charCodeAt(l)===58){s=B.xB.K(a,"%",b)
+return"["+(n?m.toLowerCase():m)+q+"]"}for(l=b;l<c;++l)if(a.charCodeAt(l)===58){s=B.xB.XU(a,"%",b)
 s=s>=b&&s<c?s:c
 if(s<c){o=s+1
-q=A.OA(a,B.xB.Y(a,"25",o)?s+3:o,c,"%25")}else q=""
+q=A.OA(a,B.xB.Qi(a,"25",o)?s+3:o,c,"%25")}else q=""
 A.eg(a,b,s)
 return"["+B.xB.Nj(a,b,s)+q+"]"}return A.OL(a,b,c)},
-to(a,b,c){var s=B.xB.K(a,"%",b)
+to(a,b,c){var s=B.xB.XU(a,"%",b)
 return s>=b&&s<c?s:c},
-OA(a,b,c,d){var s,r,q,p,o,n,m,l,k,j,i=d!==""?new A.Rn(d):null
+OA(a,b,c,d){var s,r,q,p,o,n,m,l,k,j,i=d!==""?new A.M(d):null
 for(s=b,r=s,q=!0;s<c;){p=a.charCodeAt(s)
 if(p===37){o=A.rv(a,s,!0)
 n=o==null
 if(n&&q){s+=3
-continue}if(i==null)i=new A.Rn("")
+continue}if(i==null)i=new A.M("")
 m=i.a+=B.xB.Nj(a,r,s)
 if(n)o=B.xB.Nj(a,s,s+3)
 else if(o==="%")A.R3(a,s,"ZoneID should not contain % anymore")
 i.a=m+o
 s+=3
 r=s
-q=!0}else if(p<127&&(u.b.charCodeAt(p)&1)!==0){if(q&&65<=p&&90>=p){if(i==null)i=new A.Rn("")
+q=!0}else if(p<127&&(u.f.charCodeAt(p)&1)!==0){if(q&&65<=p&&90>=p){if(i==null)i=new A.M("")
 if(r<s){i.a+=B.xB.Nj(a,r,s)
 r=s}q=!1}++s}else{l=1
 if((p&64512)===55296&&s+1<c){k=a.charCodeAt(s+1)
 if((k&64512)===56320){p=65536+((p&1023)<<10)+(k&1023)
 l=2}}j=B.xB.Nj(a,r,s)
-if(i==null){i=new A.Rn("")
+if(i==null){i=new A.M("")
 n=i}else n=i
 n.a+=j
-m=A.zX(p)
+m=A.wK(p)
 n.a+=m
 s+=l
 r=s}}if(i==null)return B.xB.Nj(a,b,c)
 if(r<c){j=B.xB.Nj(a,r,c)
 i.a+=j}n=i.a
 return n.charCodeAt(0)==0?n:n},
-OL(a,b,c){var s,r,q,p,o,n,m,l,k,j,i,h=u.b
+OL(a,b,c){var s,r,q,p,o,n,m,l,k,j,i,h=u.f
 for(s=b,r=s,q=null,p=!0;s<c;){o=a.charCodeAt(s)
 if(o===37){n=A.rv(a,s,!0)
 m=n==null
 if(m&&p){s+=3
-continue}if(q==null)q=new A.Rn("")
+continue}if(q==null)q=new A.M("")
 l=B.xB.Nj(a,r,s)
 if(!p)l=l.toLowerCase()
 k=q.a+=l
@@ -1480,7 +1707,7 @@ else if(n==="%"){n="%25"
 j=1}q.a=k+n
 s+=j
 r=s
-p=!0}else if(o<127&&(h.charCodeAt(o)&32)!==0){if(p&&65<=o&&90>=o){if(q==null)q=new A.Rn("")
+p=!0}else if(o<127&&(h.charCodeAt(o)&32)!==0){if(p&&65<=o&&90>=o){if(q==null)q=new A.M("")
 if(r<s){q.a+=B.xB.Nj(a,r,s)
 r=s}p=!1}++s}else if(o<=93&&(h.charCodeAt(o)&1024)!==0)A.R3(a,s,"Invalid character")
 else{j=1
@@ -1488,10 +1715,10 @@ if((o&64512)===55296&&s+1<c){i=a.charCodeAt(s+1)
 if((i&64512)===56320){o=65536+((o&1023)<<10)+(i&1023)
 j=2}}l=B.xB.Nj(a,r,s)
 if(!p)l=l.toLowerCase()
-if(q==null){q=new A.Rn("")
+if(q==null){q=new A.M("")
 m=q}else m=q
 m.a+=l
-k=A.zX(o)
+k=A.wK(o)
 m.a+=k
 s+=j
 r=s}}if(q==null)return B.xB.Nj(a,b,c)
@@ -1503,7 +1730,7 @@ Pi(a,b,c){var s,r,q
 if(b===c)return""
 if(!A.Et(a.charCodeAt(b)))A.R3(a,b,"Scheme not starting with alphabetic character")
 for(s=b,r=!1;s<c;++s){q=a.charCodeAt(s)
-if(!(q<128&&(u.b.charCodeAt(q)&8)!==0))A.R3(a,s,"Illegal scheme character")
+if(!(q<128&&(u.f.charCodeAt(q)&8)!==0))A.R3(a,s,"Illegal scheme character")
 if(65<=q&&q<=90)r=!0}a=B.xB.Nj(a,b,c)
 return A.Ya(r?a.toLowerCase():a)},
 Ya(a){if(a==="http")return"http"
@@ -1511,15 +1738,11 @@ if(a==="file")return"file"
 if(a==="https")return"https"
 if(a==="package")return"package"
 return a},
-zR(a,b,c){return A.PI(a,b,c,16,!1,!1)},
-ka(a,b,c,d,e,f){var s=e==="file",r=s||f,q=new A.A8(d,new A.RZ(),A.t6(d).C("A8<1,qU>")).h(0,"/")
-if(q.length===0){if(s)return"/"}else if(r&&!B.xB.v(q,"/"))q="/"+q
-return A.Jr(q,e,f)},
-Jr(a,b,c){var s=b.length===0
-if(s&&!c&&!B.xB.v(a,"/")&&!B.xB.v(a,"\\"))return A.wF(a,!s||c)
-return A.xe(a)},
+zR(a,b,c){return""},
+ka(a,b,c,d,e,f){var s=e==="file"
+return s?"/":""},
 le(a,b,c,d){return A.tS(d)},
-yf(a){var s={},r=new A.Rn("")
+yf(a){var s={},r=new A.M("")
 s.a=""
 a.aN(0,new A.fq(new A.IP(s,r)))
 s=r.a
@@ -1533,10 +1756,10 @@ q=A.oo(s)
 p=A.oo(r)
 if(q<0||p<0)return"%"
 o=q*16+p
-if(o<127&&(u.b.charCodeAt(o)&1)!==0)return A.Lw(c&&65<=o&&90>=o?(o|32)>>>0:o)
+if(o<127&&(u.f.charCodeAt(o)&1)!==0)return A.Lw(c&&65<=o&&90>=o?(o|32)>>>0:o)
 if(s>=97||r>=97)return B.xB.Nj(a,b,b+3).toUpperCase()
 return null},
-zX(a){var s,r,q,p,o,n="0123456789ABCDEF"
+wK(a){var s,r,q,p,o,n="0123456789ABCDEF"
 if(a<=127){s=new Uint8Array(3)
 s[0]=37
 s[1]=n.charCodeAt(a>>>4)
@@ -1549,63 +1772,41 @@ s[p]=37
 s[p+1]=n.charCodeAt(o>>>4)
 s[p+2]=n.charCodeAt(o&15)
 p+=3}}return A.HM(s)},
-PI(a,b,c,d,e,f){var s=A.Ul(a,b,c,d,e,f)
-return s==null?B.xB.Nj(a,b,c):s},
-Ul(a,b,c,d,e,f){var s,r,q,p,o,n,m,l,k,j=null,i=u.b
-for(s=!e,r=b,q=r,p=j;r<c;){o=a.charCodeAt(r)
-if(o<127&&(i.charCodeAt(o)&d)!==0)++r
-else{n=1
-if(o===37){m=A.rv(a,r,!1)
-if(m==null){r+=3
-continue}if("%"===m)m="%25"
-else n=3}else if(o===92&&f)m="/"
-else if(s&&o<=93&&(i.charCodeAt(o)&1024)!==0){A.R3(a,r,"Invalid character")
-n=j
-m=n}else{if((o&64512)===55296){l=r+1
-if(l<c){k=a.charCodeAt(l)
-if((k&64512)===56320){o=65536+((o&1023)<<10)+(k&1023)
-n=2}}}m=A.zX(o)}if(p==null){p=new A.Rn("")
-l=p}else l=p
-l.a=(l.a+=B.xB.Nj(a,q,r))+m
-r+=n
-q=r}}if(p==null)return j
-if(q<c){s=B.xB.Nj(a,q,c)
-p.a+=s}s=p.a
-return s.charCodeAt(0)==0?s:s},
-yB(a){if(B.xB.v(a,"."))return!0
-return B.xB.M(a,"/.")!==-1},
+yB(a){if(B.xB.nC(a,"."))return!0
+return B.xB.OY(a,"/.")!==-1},
 xe(a){var s,r,q,p,o,n
 if(!A.yB(a))return a
-s=A.j([],t.s)
+s=A.J([],t.s)
 for(r=a.split("/"),q=r.length,p=!1,o=0;o<q;++o){n=r[o]
 if(n===".."){if(s.length!==0){s.pop()
 if(s.length===0)s.push("")}p=!0}else{p="."===n
 if(!p)s.push(n)}}if(p)s.push("")
-return B.Nm.h(s,"/")},
+return B.Nm.zV(s,"/")},
 wF(a,b){var s,r,q,p,o,n
 if(!A.yB(a))return!b?A.C1(a):a
-s=A.j([],t.s)
+s=A.J([],t.s)
 for(r=a.split("/"),q=r.length,p=!1,o=0;o<q;++o){n=r[o]
-if(".."===n){p=s.length!==0&&B.Nm.gV(s)!==".."
+if(".."===n){p=s.length!==0&&B.Nm.grZ(s)!==".."
 if(p)s.pop()
 else s.push("..")}else{p="."===n
 if(!p)s.push(n)}}r=s.length
 if(r!==0)r=r===1&&s[0].length===0
 else r=!0
 if(r)return"./"
-if(p||B.Nm.gV(s)==="..")s.push("")
+if(p||B.Nm.grZ(s)==="..")s.push("")
 if(!b)s[0]=A.C1(s[0])
-return B.Nm.h(s,"/")},
+return B.Nm.zV(s,"/")},
 C1(a){var s,r,q=a.length
 if(q>=2&&A.Et(a.charCodeAt(0)))for(s=1;s<q;++s){r=a.charCodeAt(s)
 if(r===58)return B.xB.Nj(a,0,s)+"%3A"+B.xB.yn(a,s+1)
-if(r>127||(u.b.charCodeAt(r)&8)===0)break}return a},
+if(r>127||(u.f.charCodeAt(r)&8)===0)break}return a},
 Et(a){var s=a|32
 return 97<=s&&s<=122},
 bp:function bp(a){this.a=a},
+ck:function ck(){},
 Ge:function Ge(){},
 C6:function C6(a){this.a=a},
-E:function E(){},
+m:function m(){},
 AT:function AT(a,b,c,d){var _=this
 _.a=a
 _.b=b
@@ -1618,24 +1819,20 @@ _.a=c
 _.b=d
 _.c=e
 _.d=f},
-eY:function eY(a,b,c,d,e){var _=this
-_.f=a
-_.a=b
-_.b=c
-_.c=d
-_.d=e},
 ub:function ub(a){this.a=a},
 ds:function ds(a){this.a=a},
 lj:function lj(a){this.a=a},
 UV:function UV(a){this.a=a},
 k5:function k5(){},
+VS:function VS(){},
+CD:function CD(a){this.a=a},
 aE:function aE(a,b,c){this.a=a
 this.b=b
 this.c=c},
-cX:function cX(){},
 c8:function c8(){},
-a:function a(){},
-Rn:function Rn(a){this.a=a},
+Mh:function Mh(){},
+Zd:function Zd(){},
+M:function M(a){this.a=a},
 cS:function cS(a){this.a=a},
 VC:function VC(a){this.a=a},
 JT:function JT(a,b){this.a=a
@@ -1649,143 +1846,158 @@ _.e=e
 _.f=f
 _.r=g
 _.y=_.w=$},
-RZ:function RZ(){},
 IP:function IP(a,b){this.a=a
 this.b=b},
 fq:function fq(a){this.a=a},
-K(a,b,c){if(c>=1)return a.$1(b)
-return a.$0()},
-m6(a){return a==null||A.y(a)||typeof a=="number"||typeof a=="string"||t.U.b(a)||t.E.b(a)||t.e.b(a)||t.O.b(a)||t.D.b(a)||t.k.b(a)||t.v.b(a)||t.B.b(a)||t.q.b(a)||t.J.b(a)||t.Y.b(a)},
-Pe(a){if(A.m6(a))return a
-return new A.Pb(new A.YF(t.A)).$1(a)},
-Pb:function Pb(a){this.a=a},
 lM:function lM(){this.a=$},
 YE:function YE(){},
+NG:function NG(a,b,c){this.a=a
+this.b=b
+this.c=c},
+Fb:function Fb(a,b){this.a=a
+this.b=b},
+dg:function dg(a,b){this.a=a
+this.b=b},
 hy(a){if(a==null)return null
-return new A.TZ(a)},
-TZ:function TZ(a){this.a=a},
-E2(){var s,r,q,p,o=v.G,n=o.document.querySelectorAll("pre > code[data-dartpad]:only-child"),m=t.N,l=A.C(m,m)
-o=o.window
-m=new A.e(l)
-if(typeof m=="function")A.v(A.q("Attempting to rewrap a JS function."))
-s=function(a,b){return function(c){return a(b,c,arguments.length)}}(A.K,m)
-s[$.w()]=m
-o.addEventListener("message",s)
-for(o=t.m,r=0;r<n.length;++r){q=n.item(r)
-p=A.f(q==null?o.a(q):q)
-if(p!=null)l.t(0,p.b,p.a)}},
-f(a){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d=null,c="true",b=a.parentElement
-if(b==null)return d
-s=a.getAttribute("data-url")
-$label0$0:{if(s!=null){r=s.length!==0
-q=s}else{q=d
-r=!1}if(r){r=q
-break $label0$0}r="dartpad.dev"
-break $label0$0}p=A.C(t.N,t.z)
-if(!J.cf(a.getAttribute("data-embed"),"false"))p.t(0,"embed",c)
-if(J.cf(a.getAttribute("data-theme"),"light"))p.t(0,"theme","light")
-if(J.cf(a.getAttribute("data-run"),c))p.t(0,"run",c)
-o=A.Xd("https",r,"",p).gL()
-r=v.G
-n=r.document.createElement("div")
-m=r.document.createElement("iframe")
-m.setAttribute("src",o)
-l=a.getAttribute("title")
-if(l!=null){r=l.length!==0
-k=l}else{k=d
-r=!1}if(r)m.setAttribute("title",k)
-m.classList.add("embedded-dartpad")
-r=$.j1
-$.j1=r+1
-j="embedded-dartpad-"+r
-m.id=j
-m.name=j
-i=a.getAttribute("data-width")
-if(i!=null){r=i.length!==0
-h=i}else{h=d
-r=!1}if(r)m.style.width=h
-g=a.getAttribute("data-height")
-if(g!=null){r=g.length!==0
-f=g}else{f=d
-r=!1}if(r)m.style.height=f
-e=$.Ww().W(B.xB.OF(J.n(a.innerHTML)))
-n.appendChild(m)
-b.replaceWith(n)
-if(m.contentWindow==null)return d
-return new A.S0(e,j)},
-e:function e(a){this.a=a},
-pR(a){throw A.r(A.G(a),new Error())},
-Q4(){throw A.r(A.la(""),new Error())},
-kL(){throw A.r(A.G(""),new Error())}},B={}
+return new A.i1(a)},
+i1:function i1(a){this.a=a},
+E(){var s=0,r=A.F(t.n),q,p,o,n
+var $async$E=A.l(function(a,b){if(a===1)return A.x(b,r)
+while(true)switch(s){case 0:o=v.G.document.querySelectorAll("pre > code[data-dartpad]:only-child")
+n=A.J([],t.F)
+for(q=0;q<o.length;++q){p=o.item(q)
+n.push(A.f(p==null?A.A(p):p,q))}s=2
+return A.j(A.v(n,t.U),$async$E)
+case 2:return A.y(null,r)}})
+return A.D($async$E,r)},
+f(a5,a6){var s=0,r=A.F(t.U),q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4
+var $async$f=A.l(function(a7,a8){if(a7===1)return A.x(a8,r)
+while(true)switch(s){case 0:a4=a5.parentElement
+if(a4==null){q=null
+s=1
+break}p=$.Ww().WJ(B.xB.OF(J.C(a5.innerHTML)))
+if(p.length===0){q=null
+s=1
+break}o="embedded-dartpad-"+a6
+n=a5.getAttribute("data-url")
+$label0$0:{if(n!=null){m=n.length!==0
+l=n}else{l=null
+m=!1}if(m){m=l
+break $label0$0}m=null
+break $label0$0}k=J.cf(a5.getAttribute("data-embed"),"false")
+j=J.cf(a5.getAttribute("data-theme"),"light")?B.VY:B.Cp
+if(m==null)m="dartpad.dev"
+i=t.N
+i=A.Fl(i,i)
+if(!k)i.Y5(0,"embed","true")
+if(j!==B.Cp)i.Y5(0,"theme",j["["](0))
+h=A.Pi("https",0,5)
+g=A.zR(null,0,0)
+f=A.Oe(m,0,m.length,!1)
+e=A.le(null,0,0,i)
+d=A.tG(null,0,0)
+c=A.wB(null,h)
+b=h==="file"
+if(f==null)if(g.length===0)m=b
+else m=!0
+else m=!1
+if(m)f=""
+m=f==null
+a=!m
+a0=A.ka(null,0,0,null,h,a)
+k=h.length===0
+if(k&&m&&!B.xB.nC(a0,"/"))a0=A.wF(a0,!k||a)
+else a0=A.xe(a0)
+a1=new A.Dn(h,g,m&&B.xB.nC(a0,"//")?"":f,c,a0,e,d).gnD()
+k=new A.vs($.X3,t.D)
+a2=new A.NG(o,a1,new A.Zf(k,t.h))
+s=3
+return A.j(a2.qw(new A.i6(a5,a4)),$async$f)
+case 3:if((k.a&30)===0)A.vh(A.PV("EmbeddedDartPad.initialize must be called and awaited before updating the embedded source code."))
+a3=v.G.document.getElementById(o)
+if(a3==null)A.vh(A.PV("Failed to find iframe with an id of "+o+" in the document. Have you added the iframe to the document?"))
+o=A.hy(a3.contentWindow)
+if(o!=null){m={sourceCode:p,type:"sourceCode"}
+k=$.Un()
+o.a.postMessage(m,k)}q=a2
+s=1
+break
+case 1:return A.y(q,r)}})
+return A.D($async$f,r)},
+i6:function i6(a,b){this.a=a
+this.b=b},
+qw(a){if(typeof dartPrint=="function"){dartPrint(a)
+return}if(typeof console=="object"&&typeof console.log!="undefined"){console.log(a)
+return}if(typeof print=="function"){print(a)
+return}throw"Unable to print message: "+String(a)},
+K8(a,b,c){if(c>=1)return a.$1(b)
+return a.$0()}},B={}
 var w=[A,J,B]
 var $={}
 A.FK.prototype={}
 J.vB.prototype={
 DN(a,b){return a===b},
-gi(a){return A.eQ(a)},
-"["(a){return"Instance of '"+A.l(a)+"'"},
+giO(a){return A.eQ(a)},
+"["(a){return"Instance of '"+A.lh(a)+"'"},
 gbx(a){return A.Kx(A.VU(this))}}
 J.yE.prototype={
 "["(a){return String(a)},
-gi(a){return a?519018:218159},
+giO(a){return a?519018:218159},
 gbx(a){return A.Kx(t.y)},
 $iy5:1}
-J.CD.prototype={
+J.PE.prototype={
 DN(a,b){return null==b},
 "["(a){return"null"},
-gi(a){return 0},
-$iy5:1}
+giO(a){return 0},
+$iy5:1,
+$ic8:1}
 J.MF.prototype={$ivm:1}
-J.u0.prototype={
-gi(a){return 0},
+J.zh.prototype={
+giO(a){return 0},
 "["(a){return String(a)}}
 J.iC.prototype={}
 J.kd.prototype={}
 J.c5.prototype={
 "["(a){var s=a[$.w()]
 if(s==null)return this.u(a)
-return"JavaScript function for "+J.n(s)}}
+return"JavaScript function for "+J.C(s)}}
 J.rQ.prototype={
-gi(a){return 0},
+giO(a){return 0},
 "["(a){return String(a)}}
 J.Dw.prototype={
-gi(a){return 0},
+giO(a){return 0},
 "["(a){return String(a)}}
-J.p.prototype={
-FV(a,b){var s
-a.$flags&1&&A.cW(a,"addAll",2)
-for(s=b.gkz(b);s.G();)a.push(s.gl())},
-E2(a,b,c){return new A.A8(a,b,A.t6(a).C("@<1>").Kq(c).C("A8<1,2>"))},
-h(a,b){var s,r=A.O8(a.length,"",t.N)
-for(s=0;s<a.length;++s)r[s]=A.I(a[s])
+J.jd.prototype={
+zV(a,b){var s,r=A.O8(a.length,"",t.N)
+for(s=0;s<a.length;++s)r[s]=A.d(a[s])
 return r.join(b)},
-F(a,b){return a[b]},
-gV(a){var s=a.length
+XG(a,b){var s,r,q=a.length
+for(s=0;s<q;++s){r=a[s]
+if(b.$1(r))return r
+if(a.length!==q)throw A.u(A.a(a))}throw A.u(A.Wp())},
+grZ(a){var s=a.length
 if(s>0)return a[s-1]
-throw A.L(A.Wp())},
-"["(a){return A.x(a,"[","]")},
-gkz(a){return new J.D(a,a.length,A.t6(a).C("D<1>"))},
-gi(a){return A.eQ(a)},
-gB(a){return a.length},
-$ibQ:1,
-$icX:1,
+throw A.u(A.Wp())},
+"["(a){return A.k(a,"[","]")},
+gkz(a){return new J.b(a,a.length,A.c(a).C("b<1>"))},
+giO(a){return A.eQ(a)},
 $izM:1}
-J.B.prototype={
+J.BC.prototype={
 R(a){var s,r,q
 if(!Array.isArray(a))return null
 s=a.$flags|0
 if((s&4)!==0)r="const, "
 else if((s&2)!==0)r="unmodifiable, "
 else r=(s&1)!==0?"fixed, ":""
-q="Instance of '"+A.l(a)+"'"
+q="Instance of '"+A.lh(a)+"'"
 if(r==="")return q
 return q+" ("+r+"length: "+a.length+")"}}
 J.Po.prototype={}
-J.D.prototype={
+J.b.prototype={
 gl(){var s=this.d
 return s==null?this.$ti.c.a(s):s},
 G(){var s,r=this,q=r.a,p=q.length
-if(r.b!==p)throw A.L(A.lk(q))
+if(r.b!==p)throw A.u(A.q(q))
 s=r.c
 if(s>=p){r.d=null
 return!1}r.d=q[s]
@@ -1794,18 +2006,18 @@ return!0}}
 J.qI.prototype={
 "["(a){if(a===0&&1/a<0)return"-0.0"
 else return""+a},
-gi(a){var s,r,q,p,o=a|0
+giO(a){var s,r,q,p,o=a|0
 if(a===o)return o&536870911
 s=Math.abs(a)
 r=Math.log(s)/0.6931471805599453|0
 q=Math.pow(2,r)
 p=s<1?s/q:q/s
 return((p*9007199254740992|0)+(p*3542243181176521|0))*599197+r*1259&536870911},
-P(a,b){var s
+A(a,b){var s
 if(a>0)s=this.p(a,b)
 else{s=b>31?31:b
 s=a>>s>>>0}return s},
-bf(a,b){if(0>b)throw A.L(A.tL(b))
+bf(a,b){if(0>b)throw A.u(A.tL(b))
 return this.p(a,b)},
 p(a,b){return b>31?0:a>>>b},
 gbx(a){return A.Kx(t.H)},
@@ -1818,12 +2030,12 @@ J.kD.prototype={
 gbx(a){return A.Kx(t.i)},
 $iy5:1}
 J.Dr.prototype={
-Y(a,b,c){var s
-if(c<0||c>a.length)throw A.L(A.TE(c,0,a.length,null,null))
+Qi(a,b,c){var s
+if(c<0||c>a.length)throw A.u(A.TE(c,0,a.length,null,null))
 s=c+b.length
 if(s>a.length)return!1
 return b===a.substring(c,s)},
-v(a,b){return this.Y(a,b,0)},
+nC(a,b){return this.Qi(a,b,0)},
 Nj(a,b,c){return a.substring(b,A.jB(b,c,a.length))},
 yn(a,b){return this.Nj(a,b,null)},
 OF(a){var s,r=a.trimEnd(),q=r.length
@@ -1834,19 +2046,19 @@ return r.substring(0,J.c1(r,s))},
 Ix(a,b){var s,r
 if(0>=b)return""
 if(b===1||a.length===0)return a
-if(b!==b>>>0)throw A.L(B.Eq)
+if(b!==b>>>0)throw A.u(B.Eq)
 for(s=a,r="";!0;){if((b&1)===1)r=s+r
 b=b>>>1
 if(b===0)break
 s+=s}return r},
-K(a,b,c){var s
-if(c<0||c>a.length)throw A.L(A.TE(c,0,a.length,null,null))
+XU(a,b,c){var s
+if(c<0||c>a.length)throw A.u(A.TE(c,0,a.length,null,null))
 s=a.indexOf(b,c)
 return s},
-M(a,b){return this.K(a,b,0)},
-I(a,b){return A.m2(a,b,0)},
+OY(a,b){return this.XU(a,b,0)},
+tg(a,b){return A.m2(a,b,0)},
 "["(a){return a},
-gi(a){var s,r,q
+giO(a){var s,r,q
 for(s=a.length,r=0,q=0;q<s;++q){r=r+a.charCodeAt(q)&536870911
 r=r+((r&524287)<<10)&536870911
 r^=r>>6}r=r+((r&67108863)<<3)&536870911
@@ -1857,353 +2069,485 @@ $iy5:1,
 $iqU:1}
 A.SH.prototype={
 "["(a){return"LateInitializationError: "+this.a}}
-A.zl.prototype={}
-A.bQ.prototype={}
-A.aL.prototype={
-gkz(a){var s=this
-return new A.a7(s,s.gB(s),A.Lh(s).C("a7<aL.E>"))},
-h(a,b){var s,r,q,p=this,o=p.gB(p)
-if(b.length!==0){if(o===0)return""
-s=A.I(p.F(0,0))
-if(o!==p.gB(p))throw A.L(A.a4(p))
-for(r=s,q=1;q<o;++q){r=r+b+A.I(p.F(0,q))
-if(o!==p.gB(p))throw A.L(A.a4(p))}return r.charCodeAt(0)==0?r:r}else{for(q=0,r="";q<o;++q){r+=A.I(p.F(0,q))
-if(o!==p.gB(p))throw A.L(A.a4(p))}return r.charCodeAt(0)==0?r:r}},
-E2(a,b,c){return new A.A8(this,b,A.Lh(this).C("@<aL.E>").Kq(c).C("A8<1,2>"))}}
 A.a7.prototype={
 gl(){var s=this.d
 return s==null?this.$ti.c.a(s):s},
 G(){var s,r=this,q=r.a,p=J.U6(q),o=p.gB(q)
-if(r.b!==o)throw A.L(A.a4(q))
+if(r.b!==o)throw A.u(A.a(q))
 s=r.c
 if(s>=o){r.d=null
 return!1}r.d=p.F(q,s);++r.c
 return!0}}
-A.i1.prototype={
-gkz(a){var s=this.a
-return new A.MH(s.gkz(s),this.b,A.Lh(this).C("MH<1,2>"))}}
-A.xy.prototype={$ibQ:1}
-A.MH.prototype={
-G(){var s=this,r=s.b
-if(r.G()){s.a=s.c.$1(r.gl())
-return!0}s.a=null
-return!1},
-gl(){var s=this.a
-return s==null?this.$ti.y[1].a(s):s}}
-A.A8.prototype={
-gB(a){return J.Hm(this.a)},
-F(a,b){return this.b.$1(J.GA(this.a,b))}}
 A.SU.prototype={}
-A.S0.prototype={$r:"+code,id(1,2)",$s:1}
 A.rY.prototype={}
-A.t.prototype={
+A.Zr.prototype={
+q(a){var s,r,q=this,p=new RegExp(q.a).exec(a)
+if(p==null)return null
+s=Object.create(null)
+r=q.b
+if(r!==-1)s.arguments=p[r+1]
+r=q.c
+if(r!==-1)s.argumentsExpr=p[r+1]
+r=q.d
+if(r!==-1)s.expr=p[r+1]
+r=q.e
+if(r!==-1)s.method=p[r+1]
+r=q.f
+if(r!==-1)s.receiver=p[r+1]
+return s}}
+A.W0.prototype={
+"["(a){return"Null check operator used on a null value"}}
+A.az.prototype={
+"["(a){var s,r=this,q="NoSuchMethodError: method not found: '",p=r.b
+if(p==null)return"NoSuchMethodError: "+r.a
+s=r.c
+if(s==null)return q+p+"' ("+r.a+")"
+return q+p+"' on '"+s+"' ("+r.a+")"}}
+A.vV.prototype={
+"["(a){var s=this.a
+return s.length===0?"Error":"Error: "+s}}
+A.te.prototype={
+"["(a){return"Throw of null ('"+(this.a===null?"null":"undefined")+"' from JavaScript)"}}
+A.bq.prototype={}
+A.XO.prototype={
+"["(a){var s,r=this.b
+if(r!=null)return r
+r=this.a
+s=r!==null&&typeof r==="object"?r.stack:null
+return this.b=s==null?"":s},
+$iGz:1}
+A.n.prototype={
 "["(a){var s=this.constructor,r=s==null?null:s.name
-return"Closure '"+A.H(r==null?"unknown":r)+"'"},
+return"Closure '"+A.NQ(r==null?"unknown":r)+"'"},
 gKu(){return this},
 $C:"$1",
 $R:1,
 $D:null}
+A.Ay.prototype={$C:"$0",$R:0}
 A.E1.prototype={$C:"$2",$R:2}
 A.lc.prototype={}
 A.zx.prototype={
 "["(a){var s=this.$static_name
 if(s==null)return"Closure of unknown static method"
-return"Closure '"+A.H(s)+"'"}}
+return"Closure '"+A.NQ(s)+"'"}}
 A.rT.prototype={
 DN(a,b){if(b==null)return!1
 if(this===b)return!0
 if(!(b instanceof A.rT))return!1
 return this.$_target===b.$_target&&this.a===b.a},
-gi(a){return(A.CU(this.a)^A.eQ(this.$_target))>>>0},
-"["(a){return"Closure '"+this.$_name+"' of "+("Instance of '"+A.l(this.a)+"'")}}
+giO(a){return(A.CU(this.a)^A.eQ(this.$_target))>>>0},
+"["(a){return"Closure '"+this.$_name+"' of "+("Instance of '"+A.lh(this.a)+"'")}}
 A.Eq.prototype={
 "["(a){return"RuntimeError: "+this.a}}
 A.N5.prototype={
-gvc(){return new A.Gp(this,this.$ti.C("Gp<1>"))},
-WH(a,b){var s,r,q,p,o=null
-if(typeof b=="string"){s=this.b
-if(s==null)return o
-r=s[b]
-q=r==null?o:r.b
-return q}else if(typeof b=="number"&&(b&0x3fffffff)===b){p=this.c
-if(p==null)return o
-r=p[b]
-q=r==null?o:r.b
-return q}else return this.aa(b)},
-aa(a){var s,r,q=this.d
-if(q==null)return null
-s=q[J.Nu(a)&1073741823]
-r=this.X(s,a)
-if(r<0)return null
-return s[r].b},
-t(a,b,c){var s,r,q,p,o,n,m=this
+Y5(a,b,c){var s,r,q,p,o,n,m=this
 if(typeof b=="string"){s=m.b
-m.m(s==null?m.b=m.A():s,b,c)}else if(typeof b=="number"&&(b&0x3fffffff)===b){r=m.c
-m.m(r==null?m.c=m.A():r,b,c)}else{q=m.d
-if(q==null)q=m.d=m.A()
+m.u9(s==null?m.b=m.zK():s,b,c)}else if(typeof b=="number"&&(b&0x3fffffff)===b){r=m.c
+m.u9(r==null?m.c=m.zK():r,b,c)}else{q=m.d
+if(q==null)q=m.d=m.zK()
 p=J.Nu(b)&1073741823
 o=q[p]
-if(o==null)q[p]=[m.O(b,c)]
-else{n=m.X(o,b)
+if(o==null)q[p]=[m.x4(b,c)]
+else{n=m.Fh(o,b)
 if(n>=0)o[n].b=c
-else o.push(m.O(b,c))}}},
-j(a,b){var s=this.H4(this.b,b)
-return s},
+else o.push(m.x4(b,c))}}},
 aN(a,b){var s=this,r=s.e,q=s.r
 for(;r!=null;){b.$2(r.a,r.b)
-if(q!==s.r)throw A.L(A.a4(s))
+if(q!==s.r)throw A.u(A.a(s))
 r=r.c}},
-m(a,b,c){var s=a[b]
-if(s==null)a[b]=this.O(b,c)
+u9(a,b,c){var s=a[b]
+if(s==null)a[b]=this.x4(b,c)
 else s.b=c},
-H4(a,b){var s
-if(a==null)return null
-s=a[b]
-if(s==null)return null
-this.GS(s)
-delete a[b]
-return s.b},
-S(){this.r=this.r+1&1073741823},
-O(a,b){var s,r=this,q=new A.vh(a,b)
-if(r.e==null)r.e=r.f=q
-else{s=r.f
-s.toString
-q.d=s
-r.f=s.c=q}++r.a
-r.S()
-return q},
-GS(a){var s=this,r=a.d,q=a.c
-if(r==null)s.e=q
-else r.c=q
-if(q==null)s.f=r
-else q.d=r;--s.a
-s.S()},
-X(a,b){var s,r
+x4(a,b){var s=this,r=new A.db(a,b)
+if(s.e==null)s.e=s.f=r
+else s.f=s.f.c=r;++s.a
+s.r=s.r+1&1073741823
+return r},
+Fh(a,b){var s,r
 if(a==null)return-1
 s=a.length
 for(r=0;r<s;++r)if(J.cf(a[r].a,b))return r
 return-1},
 "["(a){return A.nO(this)},
-A(){var s=Object.create(null)
+zK(){var s=Object.create(null)
 s["<non-identifier-key>"]=s
 delete s["<non-identifier-key>"]
 return s}}
-A.vh.prototype={}
-A.Gp.prototype={
-gkz(a){var s=this.a
-return new A.N6(s,s.r,s.e)}}
-A.N6.prototype={
-gl(){return this.d},
-G(){var s,r=this,q=r.a
-if(r.b!==q.r)throw A.L(A.a4(q))
-s=r.c
-if(s==null){r.d=null
-return!1}else{r.d=s.a
-r.c=s.c
-return!0}}}
+A.db.prototype={}
 A.dC.prototype={
-$1(a){return this.a(a)}}
+$1(a){return this.a(a)},
+$S:7}
 A.wN.prototype={
-$2(a,b){return this.a(a,b)}}
+$2(a,b){return this.a(a,b)},
+$S:8}
 A.VX.prototype={
-$1(a){return this.a(a)}}
-A.M.prototype={
-"["(a){return this.k(!1)},
-k(a){var s,r,q,p,o,n=this.D(),m=this.n(),l=(a?"Record ":"")+"("
-for(s=n.length,r="",q=0;q<s;++q,r=", "){l+=r
-p=n[q]
-if(typeof p=="string")l=l+p+": "
-o=m[q]
-l=a?l+A.i(o):l+A.I(o)}l+=")"
-return l.charCodeAt(0)==0?l:l},
-D(){var s,r=this.$s
-for(;$.Bi.length<=r;)$.Bi.push(null)
-s=$.Bi[r]
-if(s==null){s=this.J()
-$.Bi[r]=s}return s},
-J(){var s,r,q,p=this.$r,o=p.indexOf("("),n=p.substring(1,o),m=p.substring(o),l=m==="()"?0:m.replace(/[^,]/g,"").length+1,k=A.j(new Array(l),t.f)
-for(s=0;s<l;++s)k[s]=s
-if(n!==""){r=n.split(",")
-s=r.length
-for(q=l;s>0;){--q;--s
-k[q]=r[s]}}k=A.PW(k,!1,t.K)
-k.$flags=3
-return k}}
-A.B7.prototype={
-n(){return[this.a,this.b]},
-DN(a,b){if(b==null)return!1
-return b instanceof A.B7&&this.$s===b.$s&&J.cf(this.a,b.a)&&J.cf(this.b,b.b)},
-gi(a){return A.f5(this.$s,this.a,this.b,B.zt)}}
+$1(a){return this.a(a)},
+$S:9}
 A.VR.prototype={
 "["(a){return"RegExp/"+this.a+"/"+this.b.flags}}
+A.dQ.prototype={
+D7(){var s=this.b
+if(s===this)throw A.u(new A.SH("Local '' has not been initialized."))
+return s}}
 A.WZ.prototype={
 gbx(a){return B.lb},
-$iy5:1,
-$iI2:1}
+$iy5:1}
 A.eH.prototype={}
 A.df.prototype={
 gbx(a){return B.LV},
-$iy5:1,
-$iWy:1}
+$iy5:1}
 A.b0.prototype={
 gB(a){return a.length},
 $iXj:1}
-A.Dg.prototype={$ibQ:1,$icX:1,$izM:1}
-A.DV.prototype={$ibQ:1,$icX:1,$izM:1}
+A.Dg.prototype={$izM:1}
+A.DV.prototype={$izM:1}
 A.zU.prototype={
 gbx(a){return B.Vr},
-$iy5:1,
-$ioI:1}
-A.K8.prototype={
+$iy5:1}
+A.fS.prototype={
 gbx(a){return B.mB},
-$iy5:1,
-$imJ:1}
+$iy5:1}
 A.xj.prototype={
 gbx(a){return B.x9},
-$iy5:1,
-$irF:1}
+$iy5:1}
 A.dE.prototype={
 gbx(a){return B.G3},
-$iy5:1,
-$iX6:1}
+$iy5:1}
 A.Zc.prototype={
 gbx(a){return B.xg},
-$iy5:1,
-$iZX:1}
+$iy5:1}
 A.wf.prototype={
 gbx(a){return B.Ry},
-$iy5:1,
-$iHS:1}
+$iy5:1}
 A.Pq.prototype={
 gbx(a){return B.zo},
-$iy5:1,
-$iPz:1}
+$iy5:1}
 A.eE.prototype={
 gbx(a){return B.xU},
 gB(a){return a.length},
-$iy5:1,
-$izt:1}
+$iy5:1}
 A.V6.prototype={
 gbx(a){return B.iY},
 gB(a){return a.length},
-$iy5:1,
-$in6:1}
+$iy5:1}
 A.RG.prototype={}
 A.vX.prototype={}
 A.WB.prototype={}
-A.VS.prototype={}
+A.ZG.prototype={}
 A.Jc.prototype={
-C(a){return A.cE(v.typeUniverse,this,a)},
-Kq(a){return A.v5(v.typeUniverse,this,a)}}
+C(a){return A.B(v.typeUniverse,this,a)},
+K(a){return A.v5(v.typeUniverse,this,a)}}
 A.ET.prototype={}
 A.lY.prototype={
-"["(a){return A.d(this.a,null)}}
+"["(a){return A.dm(this.a,null)}}
 A.u9.prototype={
 "["(a){return this.a}}
-A.iM.prototype={}
-A.k6.prototype={
-gvc(){return new A.Ni(this,this.$ti.C("Ni<1>"))},
-x4(a){var s,r
-if(typeof a=="string"&&a!=="__proto__"){s=this.b
-return s==null?!1:s[a]!=null}else if(typeof a=="number"&&(a&1073741823)===a){r=this.c
-return r==null?!1:r[a]!=null}else return this.KY(a)},
-KY(a){var s=this.d
-if(s==null)return!1
-return this.DF(this.e1(s,a),a)>=0},
-WH(a,b){var s,r,q
-if(typeof b=="string"&&b!=="__proto__"){s=this.b
-r=s==null?null:A.vL(s,b)
-return r}else if(typeof b=="number"&&(b&1073741823)===b){q=this.c
-r=q==null?null:A.vL(q,b)
-return r}else return this.c8(b)},
-c8(a){var s,r,q=this.d
-if(q==null)return null
-s=this.e1(q,a)
-r=this.DF(s,a)
-return r<0?null:s[r+1]},
-t(a,b,c){var s,r,q,p=this,o=p.d
-if(o==null)o=p.d=A.a0()
-s=A.CU(b)&1073741823
-r=o[s]
-if(r==null){A.a8(o,s,[b,c]);++p.a
-p.e=null}else{q=p.DF(r,b)
-if(q>=0)r[q+1]=c
-else{r.push(b,c);++p.a
-p.e=null}}},
-aN(a,b){var s,r,q,p,o,n=this,m=n.Cf()
-for(s=m.length,r=n.$ti.y[1],q=0;q<s;++q){p=m[q]
-o=n.WH(0,p)
-b.$2(p,o==null?r.a(o):o)
-if(m!==n.e)throw A.L(A.a4(n))}},
-Cf(){var s,r,q,p,o,n,m,l,k,j,i=this,h=i.e
-if(h!=null)return h
-h=A.O8(i.a,null,t.z)
-s=i.b
-r=0
-if(s!=null){q=Object.getOwnPropertyNames(s)
-p=q.length
-for(o=0;o<p;++o){h[r]=q[o];++r}}n=i.c
-if(n!=null){q=Object.getOwnPropertyNames(n)
-p=q.length
-for(o=0;o<p;++o){h[r]=+q[o];++r}}m=i.d
-if(m!=null){q=Object.getOwnPropertyNames(m)
-p=q.length
-for(o=0;o<p;++o){l=m[q[o]]
-k=l.length
-for(j=0;j<k;j+=2){h[r]=l[j];++r}}}return i.e=h},
-e1(a,b){return a[A.CU(b)&1073741823]}}
-A.YF.prototype={
-DF(a,b){var s,r,q
-if(a==null)return-1
-s=a.length
-for(r=0;r<s;r+=2){q=a[r]
-if(q==null?b==null:q===b)return r}return-1}}
-A.Ni.prototype={
-gkz(a){var s=this.a
-return new A.t3(s,s.Cf(),this.$ti.C("t3<1>"))}}
-A.t3.prototype={
-gl(){var s=this.d
-return s==null?this.$ti.c.a(s):s},
-G(){var s=this,r=s.b,q=s.c,p=s.a
-if(r!==p.e)throw A.L(A.a4(p))
-else if(q>=r.length){s.d=null
-return!1}else{s.d=r[q]
-s.c=q+1
-return!0}}}
-A.F.prototype={
-gkz(a){return new A.a7(a,a.length,A.z(a).C("a7<F.E>"))},
+A.iM.prototype={$im:1}
+A.th.prototype={
+$1(a){var s=this.a,r=s.a
+s.a=null
+r.$0()},
+$S:2}
+A.ha.prototype={
+$1(a){var s,r
+this.a.a=a
+s=this.b
+r=this.c
+s.firstChild?s.removeChild(r):s.appendChild(r)},
+$S:10}
+A.Vs.prototype={
+$0(){this.a.$0()},
+$S:3}
+A.Ft.prototype={
+$0(){this.a.$0()},
+$S:3}
+A.W3.prototype={
+P(a,b){if(self.setTimeout!=null)self.setTimeout(A.tR(new A.yH(this,b),0),a)
+else throw A.u(A.u0("`setTimeout()` not found."))}}
+A.yH.prototype={
+$0(){this.b.$0()},
+$S:0}
+A.ih.prototype={
+j(a){var s,r=this
+if(a==null)a=r.$ti.c.a(a)
+if(!r.b)r.a.D(a)
+else{s=r.a
+if(r.$ti.C("b8<1>").b(a))s.cU(a)
+else s.X2(a)}},
+k(a,b){var s=this.a
+if(this.b)s.Y(new A.OH(a,b))
+else s.i(new A.OH(a,b))}}
+A.WM.prototype={
+$1(a){return this.a.$2(0,a)},
+$S:11}
+A.SX.prototype={
+$2(a,b){this.a.$2(1,new A.bq(a,b))},
+$S:12}
+A.Gs.prototype={
+$2(a,b){this.a(a,b)},
+$S:13}
+A.OH.prototype={
+"["(a){return A.d(this.a)},
+$iGe:1,
+gn(){return this.b}}
+A.fs.prototype={
+$1(a){var s,r,q,p,o,n,m=this
+if(a===0){s=A.J([],m.c.C("jd<0>"))
+for(r=m.b,q=r.length,p=0;p<r.length;r.length===q||(0,A.q)(r),++p){o=r[p]
+n=o.b
+if(n==null)o.$ti.c.a(n)
+s.push(n)}m.a.j(s)}else{s=A.J([],t.q)
+for(r=m.b,q=r.length,p=0;p<r.length;r.length===q||(0,A.q)(r),++p)s.push(r[p].c)
+q=A.J([],m.c.C("jd<0?>"))
+for(n=r.length,p=0;p<r.length;r.length===n||(0,A.q)(r),++p)q.push(r[p].b)
+m.a.pm(new A.uH(B.Nm.XG(s,A.XJ()),a))}},
+$S:4}
+A.uH.prototype={
+"["(a){var s,r,q="ParallelWaitError",p=this.c
+if(p==null){p=this.d
+s=p<=1
+if(s)return q
+return"ParallelWaitError("+p+" errors)"}s=this.d
+r=s>1
+if(r)s="("+s+" errors)"
+else s=""
+return q+s+": "+A.d(p.a)},
+gn(){var s=this.c
+s=s==null?null:s.b
+return s==null?A.Ge.prototype.gn.call(this):s}}
+A.ru.prototype={
+v(a){this.a.S(new A.ey(this,a),new A.TM(this,a),t.P)}}
+A.ey.prototype={
+$1(a){this.a.b=a
+this.b.$1(0)},
+$S(){return this.a.$ti.C("c8(1)")}}
+A.TM.prototype={
+$2(a,b){this.a.c=new A.OH(a,b)
+this.b.$1(1)},
+$S:5}
+A.Xk.prototype={
+$1(a){var s=this.a,r=s.a+=a
+if(++s.b===this.b.length)this.c.$1(r)},
+$S:4}
+A.Pf.prototype={
+k(a,b){if((this.a.a&30)!==0)throw A.u(A.PV("Future already completed"))
+this.Y(A.ux(a,b))},
+pm(a){return this.k(a,null)}}
+A.Zf.prototype={
+j(a){var s=this.a
+if((s.a&30)!==0)throw A.u(A.PV("Future already completed"))
+s.D(a)},
+tZ(){return this.j(null)},
+Y(a){this.a.i(a)}}
+A.mJ.prototype={
+j(a){var s,r=this.a
+if((r.a&30)!==0)throw A.u(A.PV("Future already completed"))
+if(r.$ti.C("b8<1>").b(a))A.A9(a,r,!0)
+else{s=r.I()
+r.a=8
+r.c=a
+A.HZ(r,s)}},
+Y(a){this.a.Y(a)}}
+A.Fe.prototype={
+H(a){if((this.c&15)!==6)return!0
+return this.b.b.FI(this.d,a.a)},
+X(a){var s,r=this.e,q=null,p=a.a,o=this.b.b
+if(t.Q.b(r))q=o.m(r,p,a.b)
+else q=o.FI(r,p)
+try{p=q
+return p}catch(s){if(t._.b(A.Ru(s))){if((this.c&1)!==0)throw A.u(A.xY("The error handler of Future.then must return a value of the returned future's type","onError"))
+throw A.u(A.xY("The error handler of Future.catchError must return a value of the future's type","onError"))}else throw s}}}
+A.vs.prototype={
+S(a,b,c){var s,r=$.X3
+if(r===B.NU){if(!t.Q.b(b)&&!t.v.b(b))throw A.u(A.L3(b,"onError",u.c))}else b=A.VH(b,r)
+s=new A.vs(r,c.C("vs<0>"))
+this.M(new A.Fe(s,3,a,b,this.$ti.C("@<1>").K(c).C("Fe<1,2>")))
+return s},
+h(a,b,c){var s=new A.vs($.X3,c.C("vs<0>"))
+this.M(new A.Fe(s,19,a,b,this.$ti.C("@<1>").K(c).C("Fe<1,2>")))
+return s},
+L(a){this.a=this.a&1|16
+this.c=a},
+V(a){this.a=a.a&30|this.a&1
+this.c=a.c},
+M(a){var s=this,r=s.a
+if(r<=3){a.a=s.c
+s.c=a}else{if((r&4)!==0){r=s.c
+if((r.a&24)===0){r.M(a)
+return}s.V(r)}A.Tk(null,null,s.b,new A.da(s,a))}},
+T(a){var s,r,q,p,o,n=this,m={}
+m.a=a
+if(a==null)return
+s=n.a
+if(s<=3){r=n.c
+n.c=a
+if(r!=null){q=a.a
+for(p=a;q!=null;p=q,q=o)o=q.a
+p.a=r}}else{if((s&4)!==0){s=n.c
+if((s.a&24)===0){s.T(a)
+return}n.V(s)}m.a=n.J(a)
+A.Tk(null,null,n.b,new A.oQ(m,n))}},
+I(){var s=this.c
+this.c=null
+return this.J(s)},
+J(a){var s,r,q
+for(s=a,r=null;s!=null;r=s,s=q){q=s.a
+s.a=r}return r},
+X2(a){var s=this,r=s.I()
+s.a=8
+s.c=a
+A.HZ(s,r)},
+O1(a){var s,r,q=this
+if((a.a&16)!==0){s=q.b===a.b
+s=!(s||s)}else s=!1
+if(s)return
+r=q.I()
+q.V(a)
+A.HZ(q,r)},
+Y(a){var s=this.I()
+this.L(a)
+A.HZ(this,s)},
+D(a){if(this.$ti.C("b8<1>").b(a)){this.cU(a)
+return}this.wU(a)},
+wU(a){this.a^=2
+A.Tk(null,null,this.b,new A.rt(this,a))},
+cU(a){A.A9(a,this,!1)
+return},
+i(a){this.a^=2
+A.Tk(null,null,this.b,new A.xR(this,a))},
+$ib8:1}
+A.da.prototype={
+$0(){A.HZ(this.a,this.b)},
+$S:0}
+A.oQ.prototype={
+$0(){A.HZ(this.b,this.a.a)},
+$S:0}
+A.fG.prototype={
+$0(){A.A9(this.a.a,this.b,!0)},
+$S:0}
+A.rt.prototype={
+$0(){this.a.X2(this.b)},
+$S:0}
+A.xR.prototype={
+$0(){this.a.Y(this.b)},
+$S:0}
+A.RT.prototype={
+$0(){var s,r,q,p,o,n,m,l,k=this,j=null
+try{q=k.a.a
+j=q.b.b.W(q.d)}catch(p){s=A.Ru(p)
+r=A.ts(p)
+if(k.c&&k.b.a.c.a===s){q=k.a
+q.c=k.b.a.c}else{q=s
+o=r
+if(o==null)o=A.v0(q)
+n=k.a
+n.c=new A.OH(q,o)
+q=n}q.b=!0
+return}if(j instanceof A.vs&&(j.a&24)!==0){if((j.a&16)!==0){q=k.a
+q.c=j.c
+q.b=!0}return}if(j instanceof A.vs){m=k.b.a
+l=new A.vs(m.b,m.$ti)
+j.S(new A.jZ(l,m),new A.FZ(l),t.n)
+q=k.a
+q.c=l
+q.b=!1}},
+$S:0}
+A.jZ.prototype={
+$1(a){this.a.O1(this.b)},
+$S:2}
+A.FZ.prototype={
+$2(a,b){this.a.Y(new A.OH(a,b))},
+$S:5}
+A.rq.prototype={
+$0(){var s,r,q,p,o,n
+try{q=this.a
+p=q.a
+q.c=p.b.b.FI(p.d,this.b)}catch(o){s=A.Ru(o)
+r=A.ts(o)
+q=s
+p=r
+if(p==null)p=A.v0(q)
+n=this.a
+n.c=new A.OH(q,p)
+n.b=!0}},
+$S:0}
+A.vQ.prototype={
+$0(){var s,r,q,p,o,n,m,l=this
+try{s=l.a.a.c
+p=l.b
+if(p.a.H(s)&&p.a.e!=null){p.c=p.a.X(s)
+p.b=!1}}catch(o){r=A.Ru(o)
+q=A.ts(o)
+p=l.a.a.c
+if(p.a===r){n=l.b
+n.c=p
+p=n}else{p=r
+n=q
+if(n==null)n=A.v0(p)
+m=l.b
+m.c=new A.OH(p,n)
+p=m}p.b=!0}},
+$S:0}
+A.OM.prototype={}
+A.xI.prototype={}
+A.m0.prototype={}
+A.Ev.prototype={
+$0(){A.kM(this.a,this.b)},
+$S:0}
+A.Ji.prototype={
+U(a){var s,r,q
+try{if(B.NU===$.X3){a.$0()
+return}A.T8(null,null,this,a)}catch(q){s=A.Ru(q)
+r=A.ts(q)
+A.Si(s,r)}},
+t(a){return new A.Vp(this,a)},
+zz(a){if($.X3===B.NU)return a.$0()
+return A.T8(null,null,this,a)},
+W(a){return this.zz(a,t.z)},
+bv(a,b){if($.X3===B.NU)return a.$1(b)
+return A.yv(null,null,this,a,b)},
+FI(a,b){var s=t.z
+return this.bv(a,b,s,s)},
+rp(a,b,c){if($.X3===B.NU)return a.$2(b,c)
+return A.Qx(null,null,this,a,b,c)},
+m(a,b,c){var s=t.z
+return this.rp(a,b,c,s,s,s)},
+Lj(a){return a},
+O(a){var s=t.z
+return this.Lj(a,s,s,s)}}
+A.Vp.prototype={
+$0(){return this.a.U(this.b)},
+$S:0}
+A.ar.prototype={
+gkz(a){return new A.a7(a,a.length,A.z(a).C("a7<ar.E>"))},
 F(a,b){return a[b]},
-E2(a,b,c){return new A.A8(a,b,A.z(a).C("@<F.E>").Kq(c).C("A8<1,2>"))},
-"["(a){return A.x(a,"[","]")}}
+"["(a){return A.k(a,"[","]")}}
 A.il.prototype={
-aN(a,b){var s,r,q,p
-for(s=this.gvc(),s=s.gkz(s),r=A.Lh(this).y[1];s.G();){q=s.gl()
-p=this.WH(0,q)
-b.$2(q,p==null?r.a(p):p)}},
 "["(a){return A.nO(this)}}
-A.mN.prototype={
+A.GA.prototype={
 $2(a,b){var s,r=this.a
 if(!r.a)this.b.a+=", "
 r.a=!1
 r=this.b
-s=A.I(a)
+s=A.d(a)
 r.a=(r.a+=s)+": "
-s=A.I(b)
-r.a+=s}}
+s=A.d(b)
+r.a+=s},
+$S:14}
 A.Uk.prototype={}
-A.wI.prototype={}
+A.zF.prototype={}
 A.Zi.prototype={}
 A.u5.prototype={}
 A.E3.prototype={
-W(a){var s,r,q,p=A.jB(0,null,a.length)
+WJ(a){var s,r,q,p=A.jB(0,null,a.length)
 if(p===0)return new Uint8Array(0)
 s=p*3
 r=new Uint8Array(s)
 q=new A.Rw(r)
-if(q.T(a,0,p)!==p)q.H()
+if(q.Gx(a,0,p)!==p)q.RO()
 return new Uint8Array(r.subarray(0,A.rM(0,q.b,s)))}}
 A.Rw.prototype={
-H(){var s=this,r=s.c,q=s.b,p=s.b=q+1
+RO(){var s=this,r=s.c,q=s.b,p=s.b=q+1
 r.$flags&2&&A.cW(r)
 r[q]=239
 q=s.b=p+1
@@ -2223,9 +2567,9 @@ p=o.b=q+1
 r[q]=s>>>6&63|128
 o.b=p+1
 r[p]=s&63|128
-return!0}else{o.H()
+return!0}else{o.RO()
 return!1}},
-T(a,b,c){var s,r,q,p,o,n,m,l,k=this
+Gx(a,b,c){var s,r,q,p,o,n,m,l,k=this
 if(b!==c&&(a.charCodeAt(c-1)&64512)===55296)--c
 for(s=k.c,r=s.$flags|0,q=s.length,p=b;p<c;++p){o=a.charCodeAt(p)
 if(o<=127){n=k.b
@@ -2236,7 +2580,7 @@ s[n]=o}else{n=o&64512
 if(n===55296){if(k.b+4>q)break
 m=p+1
 if(k.O6(o,a.charCodeAt(m)))p=m}else if(n===56320){if(k.b+3>q)break
-k.H()}else if(o<=2047){n=k.b
+k.RO()}else if(o<=2047){n=k.b
 l=n+1
 if(l>=q)break
 k.b=l
@@ -2256,16 +2600,20 @@ A.bp.prototype={
 $2(a,b){var s,r
 if(typeof b=="string")this.a.set(a,b)
 else if(b==null)this.a.set(a,"")
-else for(s=J.IT(b),r=this.a;s.G();){b=s.gl()
+else for(s=J.I(b),r=this.a;s.G();){b=s.gl()
 if(typeof b=="string")r.append(a,b)
 else if(b==null)r.append(a,"")
-else A.ra(b)}}}
-A.Ge.prototype={}
+else A.ra(b)}},
+$S:6}
+A.ck.prototype={
+"["(a){return this.qS()}}
+A.Ge.prototype={
+gn(){return A.LU(this)}}
 A.C6.prototype={
 "["(a){var s=this.a
 if(s!=null)return"Assertion failed: "+A.h(s)
 return"Assertion failed"}}
-A.E.prototype={}
+A.m.prototype={}
 A.AT.prototype={
 gZ(){return"Invalid argument"+(!this.a?"(s)":"")},
 gN(){return""},
@@ -2277,18 +2625,11 @@ A.bJ.prototype={
 gE(){return this.b},
 gZ(){return"RangeError"},
 gN(){var s,r=this.e,q=this.f
-if(r==null)s=q!=null?": Not less than or equal to "+A.I(q):""
-else if(q==null)s=": Not greater than or equal to "+A.I(r)
-else if(q>r)s=": Not in inclusive range "+A.I(r)+".."+A.I(q)
-else s=q<r?": Valid value range is empty":": Only valid value is "+A.I(r)
+if(r==null)s=q!=null?": Not less than or equal to "+A.d(q):""
+else if(q==null)s=": Not greater than or equal to "+A.d(r)
+else if(q>r)s=": Not in inclusive range "+A.d(r)+".."+A.d(q)
+else s=q<r?": Valid value range is empty":": Only valid value is "+A.d(r)
 return s}}
-A.eY.prototype={
-gE(){return this.b},
-gZ(){return"RangeError"},
-gN(){if(this.b<0)return": index must not be negative"
-var s=this.f
-if(s===0)return": no indices are valid"
-return": index should be less than "+s}}
 A.ub.prototype={
 "["(a){return"Unsupported operation: "+this.a}}
 A.ds.prototype={
@@ -2300,7 +2641,15 @@ A.UV.prototype={
 if(s==null)return"Concurrent modification during iteration."
 return"Concurrent modification during iteration: "+A.h(s)+"."}}
 A.k5.prototype={
-"["(a){return"Out of Memory"}}
+"["(a){return"Out of Memory"},
+gn(){return null},
+$iGe:1}
+A.VS.prototype={
+"["(a){return"Stack Overflow"},
+gn(){return null},
+$iGe:1}
+A.CD.prototype={
+"["(a){return"Exception: "+this.a}}
 A.aE.prototype={
 "["(a){var s,r,q,p,o,n,m,l,k,j,i,h=this.a,g=""!==h?"FormatException: "+h:"FormatException",f=this.c,e=this.b
 if(typeof e=="string"){if(f!=null)s=f<0||f>e.length
@@ -2324,41 +2673,37 @@ j=m
 k=""}else{i=f-36
 j=f+36}l="..."}}else{j=m
 i=q
-k=""}return g+l+B.xB.Nj(e,i,j)+k+"\n"+B.xB.Ix(" ",f-i+l.length)+"^\n"}else return f!=null?g+(" (at offset "+A.I(f)+")"):g}}
-A.cX.prototype={
-E2(a,b,c){return A.K1(this,b,A.Lh(this).C("cX.E"),c)},
-gB(a){var s,r=this.gkz(this)
-for(s=0;r.G();)++s
-return s},
-F(a,b){var s,r
-A.k1(b,"index")
-s=this.gkz(this)
-for(r=b;s.G();){if(r===0)return s.gl();--r}throw A.L(A.xF(b,b-r,this,"index"))},
-"["(a){return A.Sd(this,"(",")")}}
+k=""}return g+l+B.xB.Nj(e,i,j)+k+"\n"+B.xB.Ix(" ",f-i+l.length)+"^\n"}else return f!=null?g+(" (at offset "+A.d(f)+")"):g}}
 A.c8.prototype={
-gi(a){return A.a.prototype.gi.call(this,0)},
+giO(a){return A.Mh.prototype.giO.call(this,0)},
 "["(a){return"null"}}
-A.a.prototype={$ia:1,
+A.Mh.prototype={$iMh:1,
 DN(a,b){return this===b},
-gi(a){return A.eQ(this)},
-"["(a){return"Instance of '"+A.l(this)+"'"},
+giO(a){return A.eQ(this)},
+"["(a){return"Instance of '"+A.lh(this)+"'"},
 gbx(a){return A.RW(this)},
 toString(){return this["["](this)}}
-A.Rn.prototype={
+A.Zd.prototype={
+"["(a){return""},
+$iGz:1}
+A.M.prototype={
 "["(a){var s=this.a
 return s.charCodeAt(0)==0?s:s}}
 A.cS.prototype={
-$2(a,b){throw A.L(A.rr("Illegal IPv4 address, "+a,this.a,b))}}
+$2(a,b){throw A.u(A.rr("Illegal IPv4 address, "+a,this.a,b))},
+$S:15}
 A.VC.prototype={
-$2(a,b){throw A.L(A.rr("Illegal IPv6 address, "+a,this.a,b))}}
+$2(a,b){throw A.u(A.rr("Illegal IPv6 address, "+a,this.a,b))},
+$S:16}
 A.JT.prototype={
 $2(a,b){var s
 if(b-a>4)this.a.$2("an IPv6 part can only contain a maximum of 4 hex digits",a)
 s=A.QA(B.xB.Nj(this.b,a,b),16)
 if(s<0||s>65535)this.a.$2("each part must be in the range of `0x0..0xFFFF`",a)
-return s}}
+return s},
+$S:17}
 A.Dn.prototype={
-gL(){var s,r,q,p,o=this,n=o.w
+gnD(){var s,r,q,p,o=this,n=o.w
 if(n===$){s=o.a
 r=s.length!==0?s+":":""
 q=o.c
@@ -2366,33 +2711,30 @@ p=q==null
 if(!p||s==="file"){s=r+"//"
 r=o.b
 if(r.length!==0)s=s+r+"@"
-if(!p)s+=q
-r=o.d
-if(r!=null)s=s+":"+A.I(r)}else s=r
+if(!p)s+=q}else s=r
 s+=o.e
 r=o.f
 if(r!=null)s=s+"?"+r
 r=o.r
 if(r!=null)s=s+"#"+r
-n!==$&&A.kL()
 n=o.w=s.charCodeAt(0)==0?s:s}return n},
-gi(a){var s,r=this,q=r.y
-if(q===$){s=B.xB.gi(r.gL())
+giO(a){var s,r=this,q=r.y
+if(q===$){s=B.xB.giO(r.gnD())
 r.y!==$&&A.kL()
 r.y=s
 q=s}return q},
-gq(){var s=this.c
+gJf(){var s=this.c
 if(s==null)return""
-if(B.xB.v(s,"[")&&!B.xB.Y(s,"v",1))return B.xB.Nj(s,1,s.length-1)
+if(B.xB.nC(s,"[")&&!B.xB.Qi(s,"v",1))return B.xB.Nj(s,1,s.length-1)
 return s},
-gtp(){var s=this.d
-return s==null?A.wK(this.a):s},
-"["(a){return this.gL()},
+gtp(){var s=A.GO(this.a)
+return s},
+"["(a){return this.gnD()},
 DN(a,b){var s,r,q,p,o,n=this
 if(b==null)return!1
 if(n===b)return!0
 s=!1
-if(b instanceof A.Dn)if(n.a===b.a)if(n.c!=null===(b.c!=null))if(n.b===b.b)if(n.gq()===b.gq())if(n.gtp()===b.gtp())if(n.e===b.e){r=n.f
+if(b instanceof A.Dn)if(n.a===b.a)if(n.c!=null===(b.c!=null))if(n.b===b.b)if(n.gJf()===b.gJf())if(n.gtp()===b.gtp())if(n.e===b.e){r=n.f
 q=r==null
 p=b.f
 o=p==null
@@ -2403,8 +2745,6 @@ p=b.r
 o=p==null
 if(!q===!o){s=q?"":r
 s=s===(o?"":p)}}}}return s}}
-A.RZ.prototype={
-$1(a){return A.eP(64,a,B.xM,!1)}}
 A.IP.prototype={
 $2(a,b){var s=this.b,r=this.a
 s.a+=r.a
@@ -2413,36 +2753,26 @@ r=A.eP(1,a,B.xM,!0)
 r=s.a+=r
 if(b!=null&&b.length!==0){s.a=r+"="
 r=A.eP(1,b,B.xM,!0)
-s.a+=r}}}
+s.a+=r}},
+$S:18}
 A.fq.prototype={
 $2(a,b){var s,r
 if(b==null||typeof b=="string")this.a.$2(a,b)
-else for(s=J.IT(b),r=this.a;s.G();)r.$2(a,s.gl())}}
-A.Pb.prototype={
-$1(a){var s,r,q,p
-if(A.m6(a))return a
-s=this.a
-if(s.x4(a))return s.WH(0,a)
-if(a instanceof A.il){r={}
-s.t(0,a,r)
-for(s=a.gvc(),s=s.gkz(s);s.G();){q=s.gl()
-r[q]=this.$1(a.WH(0,q))}return r}else if(t.V.b(a)){p=[]
-s.t(0,a,p)
-B.Nm.FV(p,J.M1(a,this,t.z))
-return p}else return a}}
+else for(s=J.I(b),r=this.a;s.G();)r.$2(a,s.gl())},
+$S:6}
 A.lM.prototype={}
 A.YE.prototype={
-U(){this.a=Math.max(18,5)},
-W(a){var s,r,q,p,o,n,m,l,k,j,i,h,g,f
-if(!B.xB.I(a,"&"))return a
-s=new A.Rn("")
-for(r=a.length,q=0;!0;){p=B.xB.K(a,"&",q)
+Ny(){this.a=Math.max(18,5)},
+WJ(a){var s,r,q,p,o,n,m,l,k,j,i,h,g,f
+if(!B.xB.tg(a,"&"))return a
+s=new A.M("")
+for(r=a.length,q=0;!0;){p=B.xB.XU(a,"&",q)
 if(p===-1){s.a+=B.xB.yn(a,q)
 break}o=s.a+=B.xB.Nj(a,q,p)
 n=this.a
 n===$&&A.Q4()
 m=B.xB.Nj(a,p,Math.min(r,p+n))
-if(m.length>4&&m.charCodeAt(1)===35){l=B.xB.M(m,";")
+if(m.length>4&&m.charCodeAt(1)===35){l=B.xB.OY(m,";")
 if(l!==-1){k=m.charCodeAt(2)===120
 j=B.xB.Nj(m,k?3:2,l)
 i=A.Hp(j,k?16:10)
@@ -2453,75 +2783,128 @@ continue}}}g=0
 while(!0){if(!(g<268)){q=p
 h=!1
 break}f=B.uu[g]
-if(B.xB.v(m,f)){s.a+=B.nO[g]
+if(B.xB.nC(m,f)){s.a+=B.nO[g]
 q=p+f.length
 h=!0
 break}++g}if(!h){s.a+="&";++q}}r=s.a
 return r.charCodeAt(0)==0?r:r}}
-A.TZ.prototype={}
-A.e.prototype={
-$1(a){var s,r,q,p,o,n,m=null,l=a.data,k=t.m,j=m,i=!1
-if(k.b(l)){s=l.type
-r=s
-if(r!=null){q=s==null?A.Bt(s):s
-p=l.sender
-r=p
-if(r!=null){j=p==null?A.Bt(p):p
-i=q==="ready"}}}if(i){i=this.a
-o=i.WH(0,j)
-if(o!=null){n=v.G.document.getElementById(j)
-if(n==null)n=k.a(n)
-k=A.hy(n.contentWindow)
-if(k!=null){r=t.N
-r=A.Pe(A.EF(["sourceCode",o,"type","sourceCode"],r,r))
-k.a.postMessage(r,"*")}i.j(0,j)}}}};(function aliases(){var s=J.u0.prototype
-s.u=s["["]})();(function inheritance(){var s=hunkHelpers.mixin,r=hunkHelpers.inherit,q=hunkHelpers.inheritMany
-r(A.a,null)
-q(A.a,[A.FK,J.vB,A.rY,J.D,A.Ge,A.zl,A.cX,A.a7,A.MH,A.SU,A.M,A.t,A.il,A.vh,A.N6,A.VR,A.Jc,A.ET,A.lY,A.t3,A.F,A.Uk,A.wI,A.Rw,A.k5,A.aE,A.c8,A.Rn,A.Dn,A.TZ])
-q(J.vB,[J.yE,J.CD,J.MF,J.rQ,J.Dw,J.qI,J.Dr])
-q(J.MF,[J.u0,J.p,A.WZ,A.eH])
-q(J.u0,[J.iC,J.kd,J.c5])
-r(J.B,A.rY)
-r(J.Po,J.p)
+A.NG.prototype={
+qw(a){var s=0,r=A.F(t.n),q,p=this,o,n,m,l,k
+var $async$qw=A.l(function(b,c){if(b===1)return A.x(c,r)
+while(true)switch(s){case 0:k=p.c.a
+if((k.a&30)!==0){s=1
+break}o=A.wX()
+n=new A.Fb(p,o)
+if(typeof n=="function")A.vh(A.xY("Attempting to rewrap a JS function.",null))
+m=function(d,e){return function(f){return d(e,f,arguments.length)}}(A.K8,n)
+m[$.w()]=n
+if(o.b!==o)A.vh(new A.SH("Local '' has already been initialized."))
+o.b=m
+n=v.G
+n.window.addEventListener("message",o.D7())
+l=n.document.createElement("iframe")
+l.src=p.b
+n=p.a
+l.id=n
+l.name=n
+l.loading="lazy"
+l.allow="clipboard-write"
+a.$1(l)
+s=3
+return A.j(k,$async$qw)
+case 3:case 1:return A.y(q,r)}})
+return A.D($async$qw,r)}}
+A.Fb.prototype={
+$1(a){var s,r,q,p=a.data,o=null,n=!1
+if(t.m.b(p)){s="ready"===p.type
+if(s){r=p.sender
+n=r
+o=n
+n=n!=null}}else s=!1
+if(n){q=s?o:p.sender
+if(q==null)q=A.Bt(q)
+n=this.a
+if(q!==n.a)return
+v.G.window.removeEventListener("message",this.b.D7())
+n=n.c
+if((n.a.a&30)===0)n.tZ()}},
+$S:19}
+A.dg.prototype={
+qS(){return"DartPadTheme."+this.b}}
+A.i1.prototype={}
+A.i6.prototype={
+$1(a){var s,r,q,p,o,n,m,l,k
+a.classList.add("embedded-dartpad")
+s=this.a
+r=s.getAttribute("title")
+if(r!=null){q=r.length!==0
+p=r}else{p=null
+q=!1}if(q)a.setAttribute("title",p)
+o=s.getAttribute("data-width")
+if(o!=null){q=o.length!==0
+n=o}else{n=null
+q=!1}if(q)a.style.width=n
+m=s.getAttribute("data-height")
+if(m!=null){s=m.length!==0
+l=m}else{l=null
+s=!1}if(s)a.style.height=l
+k=v.G.document.createElement("div")
+k.appendChild(a)
+s=this.b
+s.replaceWith(k)
+if(a.contentWindow==null){k.replaceWith(s)
+A.qw("Failed to inject embedded DartPad with content:\n")}},
+$S:20};(function aliases(){var s=J.zh.prototype
+s.u=s["["]})();(function installTearOffs(){var s=hunkHelpers._static_1,r=hunkHelpers._static_0
+s(A,"EX","ZV",1)
+s(A,"yt","oA",1)
+s(A,"qW","Bz",1)
+s(A,"XJ","tC",21)
+r(A,"UI","eN",0)})();(function inheritance(){var s=hunkHelpers.mixin,r=hunkHelpers.inherit,q=hunkHelpers.inheritMany
+r(A.Mh,null)
+q(A.Mh,[A.FK,J.vB,A.rY,J.b,A.Ge,A.a7,A.SU,A.Zr,A.te,A.bq,A.XO,A.n,A.il,A.db,A.VR,A.dQ,A.Jc,A.ET,A.lY,A.W3,A.ih,A.OH,A.ru,A.Pf,A.Fe,A.vs,A.OM,A.xI,A.m0,A.ar,A.Uk,A.zF,A.Rw,A.ck,A.k5,A.VS,A.CD,A.aE,A.c8,A.Zd,A.M,A.Dn,A.NG,A.i1])
+q(J.vB,[J.yE,J.PE,J.MF,J.rQ,J.Dw,J.qI,J.Dr])
+q(J.MF,[J.zh,J.jd,A.WZ,A.eH])
+q(J.zh,[J.iC,J.kd,J.c5])
+r(J.BC,A.rY)
+r(J.Po,J.jd)
 q(J.qI,[J.im,J.kD])
-q(A.Ge,[A.SH,A.Eq,A.u9,A.C6,A.E,A.AT,A.ub,A.ds,A.lj,A.UV])
-q(A.cX,[A.bQ,A.i1])
-q(A.bQ,[A.aL,A.Gp,A.Ni])
-r(A.xy,A.i1)
-r(A.A8,A.aL)
-r(A.B7,A.M)
-r(A.S0,A.B7)
-q(A.t,[A.E1,A.lc,A.dC,A.VX,A.RZ,A.Pb,A.e])
+q(A.Ge,[A.SH,A.m,A.az,A.vV,A.Eq,A.u9,A.uH,A.C6,A.AT,A.ub,A.ds,A.lj,A.UV])
+r(A.W0,A.m)
+q(A.n,[A.Ay,A.E1,A.lc,A.dC,A.VX,A.th,A.ha,A.WM,A.fs,A.ey,A.Xk,A.jZ,A.Fb,A.i6])
 q(A.lc,[A.zx,A.rT])
-q(A.il,[A.N5,A.k6])
-q(A.E1,[A.wN,A.mN,A.bp,A.cS,A.VC,A.JT,A.IP,A.fq])
+r(A.N5,A.il)
+q(A.E1,[A.wN,A.SX,A.Gs,A.TM,A.FZ,A.GA,A.bp,A.cS,A.VC,A.JT,A.IP,A.fq])
 q(A.eH,[A.df,A.b0])
 q(A.b0,[A.RG,A.WB])
 r(A.vX,A.RG)
 r(A.Dg,A.vX)
-r(A.VS,A.WB)
-r(A.DV,A.VS)
-q(A.Dg,[A.zU,A.K8])
+r(A.ZG,A.WB)
+r(A.DV,A.ZG)
+q(A.Dg,[A.zU,A.fS])
 q(A.DV,[A.xj,A.dE,A.Zc,A.wf,A.Pq,A.eE,A.V6])
 r(A.iM,A.u9)
-r(A.YF,A.k6)
+q(A.Ay,[A.Vs,A.Ft,A.yH,A.da,A.oQ,A.fG,A.rt,A.xR,A.RT,A.rq,A.vQ,A.Ev,A.Vp])
+q(A.Pf,[A.Zf,A.mJ])
+r(A.Ji,A.m0)
 r(A.Zi,A.Uk)
 r(A.u5,A.Zi)
-q(A.wI,[A.E3,A.YE])
-q(A.AT,[A.bJ,A.eY])
+q(A.zF,[A.E3,A.YE])
+r(A.bJ,A.AT)
 r(A.lM,A.YE)
-s(A.RG,A.F)
+r(A.dg,A.ck)
+s(A.RG,A.ar)
 s(A.vX,A.SU)
-s(A.WB,A.F)
-s(A.VS,A.SU)})()
-var v={G:typeof self!="undefined"?self:globalThis,typeUniverse:{eC:new Map(),tR:{},eT:{},tPV:{},sEA:[]},mangledGlobalNames:{KN:"int",CP:"double",lf:"num",qU:"String",a2:"bool",c8:"Null",zM:"List",a:"Object",T8:"Map"},mangledNames:{},types:[],interceptorsByTag:null,leafTags:null,arrayRti:Symbol("$ti"),rttc:{"2;code,id":(a,b)=>c=>c instanceof A.S0&&a.b(c.a)&&b.b(c.b)}}
-A.xb(v.typeUniverse,JSON.parse('{"iC":"u0","kd":"u0","c5":"u0","yE":{"y5":[]},"CD":{"y5":[]},"MF":{"vm":[]},"u0":{"vm":[]},"p":{"zM":["1"],"bQ":["1"],"vm":[],"cX":["1"]},"B":{"rY":[]},"Po":{"p":["1"],"zM":["1"],"bQ":["1"],"vm":[],"cX":["1"]},"qI":{"CP":[]},"im":{"CP":[],"KN":[],"y5":[]},"kD":{"CP":[],"y5":[]},"Dr":{"qU":[],"y5":[]},"bQ":{"cX":["1"]},"aL":{"bQ":["1"],"cX":["1"]},"i1":{"cX":["2"],"cX.E":"2"},"xy":{"i1":["1","2"],"bQ":["2"],"cX":["2"],"cX.E":"2"},"A8":{"aL":["2"],"bQ":["2"],"cX":["2"],"aL.E":"2","cX.E":"2"},"N5":{"il":["1","2"]},"Gp":{"bQ":["1"],"cX":["1"],"cX.E":"1"},"WZ":{"vm":[],"I2":[],"y5":[]},"eH":{"vm":[]},"df":{"Wy":[],"vm":[],"y5":[]},"b0":{"Xj":["1"],"vm":[]},"Dg":{"F":["CP"],"zM":["CP"],"Xj":["CP"],"bQ":["CP"],"vm":[],"cX":["CP"]},"DV":{"F":["KN"],"zM":["KN"],"Xj":["KN"],"bQ":["KN"],"vm":[],"cX":["KN"]},"zU":{"oI":[],"F":["CP"],"zM":["CP"],"Xj":["CP"],"bQ":["CP"],"vm":[],"cX":["CP"],"y5":[],"F.E":"CP"},"K8":{"mJ":[],"F":["CP"],"zM":["CP"],"Xj":["CP"],"bQ":["CP"],"vm":[],"cX":["CP"],"y5":[],"F.E":"CP"},"xj":{"rF":[],"F":["KN"],"zM":["KN"],"Xj":["KN"],"bQ":["KN"],"vm":[],"cX":["KN"],"y5":[],"F.E":"KN"},"dE":{"X6":[],"F":["KN"],"zM":["KN"],"Xj":["KN"],"bQ":["KN"],"vm":[],"cX":["KN"],"y5":[],"F.E":"KN"},"Zc":{"ZX":[],"F":["KN"],"zM":["KN"],"Xj":["KN"],"bQ":["KN"],"vm":[],"cX":["KN"],"y5":[],"F.E":"KN"},"wf":{"HS":[],"F":["KN"],"zM":["KN"],"Xj":["KN"],"bQ":["KN"],"vm":[],"cX":["KN"],"y5":[],"F.E":"KN"},"Pq":{"Pz":[],"F":["KN"],"zM":["KN"],"Xj":["KN"],"bQ":["KN"],"vm":[],"cX":["KN"],"y5":[],"F.E":"KN"},"eE":{"zt":[],"F":["KN"],"zM":["KN"],"Xj":["KN"],"bQ":["KN"],"vm":[],"cX":["KN"],"y5":[],"F.E":"KN"},"V6":{"n6":[],"F":["KN"],"zM":["KN"],"Xj":["KN"],"bQ":["KN"],"vm":[],"cX":["KN"],"y5":[],"F.E":"KN"},"k6":{"il":["1","2"]},"YF":{"k6":["1","2"],"il":["1","2"]},"Ni":{"bQ":["1"],"cX":["1"],"cX.E":"1"},"zM":{"bQ":["1"],"cX":["1"]},"ZX":{"zM":["KN"],"bQ":["KN"],"cX":["KN"]},"n6":{"zM":["KN"],"bQ":["KN"],"cX":["KN"]},"zt":{"zM":["KN"],"bQ":["KN"],"cX":["KN"]},"rF":{"zM":["KN"],"bQ":["KN"],"cX":["KN"]},"HS":{"zM":["KN"],"bQ":["KN"],"cX":["KN"]},"X6":{"zM":["KN"],"bQ":["KN"],"cX":["KN"]},"Pz":{"zM":["KN"],"bQ":["KN"],"cX":["KN"]},"oI":{"zM":["CP"],"bQ":["CP"],"cX":["CP"]},"mJ":{"zM":["CP"],"bQ":["CP"],"cX":["CP"]}}'))
-A.FF(v.typeUniverse,JSON.parse('{"bQ":1,"SU":1,"N6":1,"b0":1,"Uk":2,"wI":2}'))
-var u={b:"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\u03f6\x00\u0404\u03f4 \u03f4\u03f6\u01f6\u01f6\u03f6\u03fc\u01f4\u03ff\u03ff\u0584\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u05d4\u01f4\x00\u01f4\x00\u0504\u05c4\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u0400\x00\u0400\u0200\u03f7\u0200\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u0200\u0200\u0200\u03f7\x00"}
+s(A.WB,A.ar)
+s(A.ZG,A.SU)})()
+var v={G:typeof self!="undefined"?self:globalThis,typeUniverse:{eC:new Map(),tR:{},eT:{},tPV:{},sEA:[]},mangledGlobalNames:{KN:"int",CP:"double",lf:"num",qU:"String",a2:"bool",c8:"Null",zM:"List",Mh:"Object",Z0:"Map",vm:"JSObject"},mangledNames:{},types:["~()","~(~())","c8(@)","c8()","~(KN)","c8(Mh,Gz)","~(qU,@)","@(@)","@(@,qU)","@(qU)","c8(~())","~(@)","c8(@,Gz)","~(KN,@)","~(Mh?,Mh?)","~(qU,KN)","~(qU,KN?)","KN(KN,KN)","~(qU,qU?)","c8(vm)","~(vm)","a2(Mh?)"],interceptorsByTag:null,leafTags:null,arrayRti:Symbol("$ti")}
+A.xb(v.typeUniverse,JSON.parse('{"iC":"zh","kd":"zh","c5":"zh","Fu":"WZ","yE":{"y5":[]},"PE":{"c8":[],"y5":[]},"MF":{"vm":[]},"zh":{"vm":[]},"jd":{"zM":["1"],"vm":[]},"BC":{"rY":[]},"Po":{"jd":["1"],"zM":["1"],"vm":[]},"qI":{"CP":[]},"im":{"CP":[],"KN":[],"y5":[]},"kD":{"CP":[],"y5":[]},"Dr":{"qU":[],"y5":[]},"SH":{"Ge":[]},"W0":{"m":[],"Ge":[]},"az":{"Ge":[]},"vV":{"Ge":[]},"XO":{"Gz":[]},"Eq":{"Ge":[]},"N5":{"il":["1","2"]},"WZ":{"vm":[],"y5":[]},"eH":{"vm":[]},"df":{"vm":[],"y5":[]},"b0":{"Xj":["1"],"vm":[]},"Dg":{"ar":["CP"],"zM":["CP"],"Xj":["CP"],"vm":[]},"DV":{"ar":["KN"],"zM":["KN"],"Xj":["KN"],"vm":[]},"zU":{"ar":["CP"],"zM":["CP"],"Xj":["CP"],"vm":[],"y5":[],"ar.E":"CP"},"fS":{"ar":["CP"],"zM":["CP"],"Xj":["CP"],"vm":[],"y5":[],"ar.E":"CP"},"xj":{"ar":["KN"],"zM":["KN"],"Xj":["KN"],"vm":[],"y5":[],"ar.E":"KN"},"dE":{"ar":["KN"],"zM":["KN"],"Xj":["KN"],"vm":[],"y5":[],"ar.E":"KN"},"Zc":{"ar":["KN"],"zM":["KN"],"Xj":["KN"],"vm":[],"y5":[],"ar.E":"KN"},"wf":{"ar":["KN"],"zM":["KN"],"Xj":["KN"],"vm":[],"y5":[],"ar.E":"KN"},"Pq":{"ar":["KN"],"zM":["KN"],"Xj":["KN"],"vm":[],"y5":[],"ar.E":"KN"},"eE":{"ar":["KN"],"zM":["KN"],"Xj":["KN"],"vm":[],"y5":[],"ar.E":"KN"},"V6":{"ar":["KN"],"zM":["KN"],"Xj":["KN"],"vm":[],"y5":[],"ar.E":"KN"},"u9":{"Ge":[]},"iM":{"m":[],"Ge":[]},"OH":{"Ge":[]},"uH":{"Ge":[]},"Zf":{"Pf":["1"]},"mJ":{"Pf":["1"]},"vs":{"b8":["1"]},"C6":{"Ge":[]},"m":{"Ge":[]},"AT":{"Ge":[]},"bJ":{"Ge":[]},"ub":{"Ge":[]},"ds":{"Ge":[]},"lj":{"Ge":[]},"UV":{"Ge":[]},"k5":{"Ge":[]},"VS":{"Ge":[]},"Zd":{"Gz":[]},"ZX":{"zM":["KN"]},"n6":{"zM":["KN"]},"zt":{"zM":["KN"]},"rF":{"zM":["KN"]},"yc":{"zM":["KN"]},"X6":{"zM":["KN"]},"Pz":{"zM":["KN"]},"oI":{"zM":["CP"]},"cQ":{"zM":["CP"]}}'))
+A.FF(v.typeUniverse,JSON.parse('{"SU":1,"b0":1,"uH":2,"xI":1,"Uk":2,"zF":2}'))
+var u={f:"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\u03f6\x00\u0404\u03f4 \u03f4\u03f6\u01f6\u01f6\u03f6\u03fc\u01f4\u03ff\u03ff\u0584\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u05d4\u01f4\x00\u01f4\x00\u0504\u05c4\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u0400\x00\u0400\u0200\u03f7\u0200\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u03ff\u0200\u0200\u0200\u03f7\x00",c:"Error handler must accept one Object or one Object and a StackTrace as arguments, and return a value of the returned future's type"}
 var t=(function rtii(){var s=A.q7
-return{J:s("I2"),Y:s("Wy"),Q:s("bQ<@>"),B:s("oI"),q:s("mJ"),Z:s("EH"),O:s("rF"),k:s("X6"),U:s("ZX"),V:s("cX<@>"),f:s("p<a>"),s:s("p<qU>"),b:s("p<@>"),t:s("p<KN>"),T:s("CD"),m:s("vm"),g:s("c5"),p:s("Xj<@>"),j:s("zM<@>"),P:s("c8"),K:s("a"),L:s("VY"),F:s("+()"),N:s("qU"),R:s("y5"),D:s("HS"),v:s("Pz"),e:s("zt"),E:s("n6"),o:s("kd"),A:s("YF<a?,a?>"),y:s("a2"),i:s("CP"),z:s("@"),S:s("KN"),W:s("b8<c8>?"),X:s("a?"),w:s("qU?"),u:s("a2?"),I:s("CP?"),x:s("KN?"),n:s("lf?"),H:s("lf")}})();(function constants(){var s=hunkHelpers.makeConstList
+return{C:s("Ge"),Z:s("EH"),F:s("jd<b8<NG?>>"),s:s("jd<qU>"),b:s("jd<@>"),t:s("jd<KN>"),q:s("jd<OH?>"),T:s("PE"),m:s("vm"),g:s("c5"),p:s("Xj<@>"),j:s("zM<@>"),P:s("c8"),K:s("Mh"),L:s("VY"),l:s("Gz"),N:s("qU"),R:s("y5"),_:s("m"),o:s("kd"),h:s("Zf<~>"),c:s("vs<@>"),D:s("vs<~>"),y:s("a2"),i:s("CP"),z:s("@"),v:s("@(Mh)"),Q:s("@(Mh,Gz)"),S:s("KN"),U:s("NG?"),O:s("b8<c8>?"),A:s("vm?"),X:s("Mh?"),w:s("qU?"),u:s("a2?"),I:s("CP?"),x:s("KN?"),B:s("lf?"),H:s("lf"),n:s("~")}})();(function constants(){var s=hunkHelpers.makeConstList
 B.Ok=J.vB.prototype
-B.Nm=J.p.prototype
+B.Nm=J.jd.prototype
 B.jn=J.im.prototype
 B.xB=J.Dr.prototype
 B.DG=J.c5.prototype
@@ -2654,24 +3037,26 @@ B.fQ=function(hooks) {
 B.i7=function(hooks) { return hooks; }
 
 B.Eq=new A.k5()
-B.zt=new A.zl()
 B.xM=new A.u5()
 B.Qk=new A.E3()
+B.NU=new A.Ji()
+B.pd=new A.Zd()
+B.VY=new A.dg(0,"light")
+B.Cp=new A.dg(2,"auto")
 B.nO=s(["`","\xa0","\xb4","|","\xb7","\xa8","\xb1","\xb7","_","\xae","\xb8","\n","\xa6","%","*","{","|",".","}","\xfd","\xa4","\xfa","\xf5","=","\xf9","@","\xf8","\xb1","\xf7","[","$","\xb7","]","\xd3","_","\xbc","\xbd","\xbe","\xbf","\xc0","\xc1","\xc3","\xf3","\xc8","\xc9","\xcc","\xcd","\xd1","\xd2","\xd5","\xd8","\xd9","\xda","\xdd","\xe0","\xe1","\xe3","\xe7","\xe8","\xe9","\xec","\xed","\xf1","\xf2","\xc7","\xea","\xb4","\xa4","\xf4","\xa6","\xf3","\xa3","\xf2","\xf9","\xf1",":","\xab","\xee","\xf8","\xed","\xfe","\xfd","\xf7","\xc8","\xec","\xaf","\xa1","\xb1","\xe9","\xdf","\xe8","\xb5","\xe7","\xb7","\xb8","\xfb","\xe6",",","\xbb","\xfa","\xbc","\xbd","?","\xbe","\xbf","\xc0","\xc1","\xc2","\xc3","\xc5","\xc5","\xc6","\xe5","\xde","\xc9","\xca","\xcc","\xe3","\xcd","\xce","\xe2","`","\xd1","\xd2","\xe1","\xd3","\xd4","f","\xd5","\xe0","\xd7","\xf5","\xd8","\xd9","\xda","\xdb","\xdd","\xc7","\xaf","\xb2","[",";","\xb3","\xc2","\\","+","\xc4","\xe5","\xf4","\xb4","\xc5","\xa7","\xc6","\xa9","\xb5","]","\xd7","\xff","\xb6","\xa2","\xca","\xcb","\xe4","\xfe","\xa0","\xfc","\xf6","\xfb","\xce","\xcf","}","\xe2","\xa9","\xb8","\xa1","'","\xb9","\xaa","\xba","\xef","\xd4","\xa3","\xbb","\xd6","\xab","\xeb",">","(",'"',"{","\xbd",")","\xee","\xea","\xdb","\xdc","\xdf","|","!","<","\xde",'"',"\xe6","=","\xd6",'"',"\xff","\xf6","\xd0","\xcf","&","\xcb","\xe4","&","\xc4","\xb9","\xba","*","\xb6","\xa0","#","\xb3","\xb2","\xad","\xfc","\xf7","\xeb","\xb0","\xaf","\xae","\xae","\xdc","\xac","\xaa","\xef","\xf0","\xa9","\xa9","\xa8","\xa2","\xa8","\xa8","\xa7","/",'"',"\xa5","\t","^","\xd0","\xb1","\xb0","\xae","\xae","\xad","\xac","\xa8","\xa5",">",">","<","<","&","&","\xf0",">",">","<","<"],t.s)
 B.uu=s(["&DiacriticalGrave;","&NonBreakingSpace;","&DiacriticalAcute;","&VerticalLine;","&centerdot;","&DoubleDot;","&PlusMinus;","&CenterDot;","&UnderBar;","&circledR;","&Cedilla;","&NewLine;","&brvbar;","&percnt;","&midast;","&lbrace;","&verbar;","&period;","&rbrace;","&yacute;","&curren;","&uacute;","&otilde;","&equals;","&ugrave;","&commat;","&oslash;","&plusmn;","&divide;","&lbrack;","&dollar;","&middot;","&rbrack;","&Oacute;","&lowbar;","&frac14;","&frac12;","&frac34;","&iquest;","&Agrave;","&Aacute;","&Atilde;","&oacute;","&Egrave;","&Eacute;","&Igrave;","&Iacute;","&Ntilde;","&Ograve;","&Otilde;","&Oslash;","&Ugrave;","&Uacute;","&Yacute;","&agrave;","&aacute;","&atilde;","&ccedil;","&egrave;","&eacute;","&igrave;","&iacute;","&ntilde;","&ograve;","&Ccedil;","&ecirc;","&acute;","&curren","&ocirc;","&brvbar","&oacute","&pound;","&ograve","&ugrave","&ntilde","&colon;","&laquo;","&icirc;","&oslash","&iacute","&thorn;","&yacute","&divide","&Egrave","&igrave","&strns;","&iexcl;","&plusmn","&eacute","&szlig;","&egrave","&micro;","&ccedil","&middot","&cedil;","&ucirc;","&aelig;","&comma;","&raquo;","&uacute","&frac14","&frac12","&quest;","&frac34","&iquest","&Agrave","&Aacute","&Acirc;","&Atilde","&Aring;","&angst;","&AElig;","&aring;","&THORN;","&Eacute","&Ecirc;","&Igrave","&atilde","&Iacute","&Icirc;","&acirc;","&grave;","&Ntilde","&Ograve","&aacute","&Oacute","&Ocirc;","&fjlig;","&Otilde","&agrave","&times;","&otilde","&Oslash","&Ugrave","&Uacute","&Ucirc;","&Yacute","&Ccedil","&macr;","&sup2;","&lsqb;","&semi;","&sup3;","&Acirc","&bsol;","&plus;","&Auml;","&aring","&ocirc","&acute","&Aring","&sect;","&AElig","&copy;","&micro","&rsqb;","&times","&yuml;","&para;","&cent;","&Ecirc","&Euml;","&auml;","&thorn","&nbsp;","&uuml;","&ouml;","&ucirc","&Icirc","&Iuml;","&rcub;","&acirc","&COPY;","&cedil","&iexcl","&apos;","&sup1;","&ordf;","&ordm;","&iuml;","&Ocirc","&pound","&raquo","&Ouml;","&laquo","&euml;","&nvgt;","&lpar;","&QUOT;","&lcub;","&half;","&rpar;","&icirc","&ecirc","&Ucirc","&Uuml;","&szlig","&vert;","&excl;","&nvlt;","&THORN","&quot;","&aelig","&bne;","&Ouml","&quot","&yuml","&ouml","&ETH;","&Iuml","&AMP;","&Euml","&auml","&amp;","&Auml","&sup1","&ordm","&ast;","&para","&nbsp","&num;","&sup3","&sup2","&shy;","&uuml","&div;","&euml","&deg;","&macr","&REG;","&reg;","&Uuml","&not;","&ordf","&iuml","&eth;","&COPY","&copy","&Dot;","&cent","&die;","&uml;","&sect","&sol;","&QUOT","&yen;","&Tab;","&Hat;","&ETH","&pm;","&deg","&REG","&reg","&shy","&not","&uml","&yen","&GT;","&gt;","&LT;","&lt;","&AMP","&amp","&eth","&GT","&gt","&LT","&lt"],t.s)
 B.lb=A.xq("I2")
 B.LV=A.xq("Wy")
 B.Vr=A.xq("oI")
-B.mB=A.xq("mJ")
+B.mB=A.xq("cQ")
 B.x9=A.xq("rF")
 B.G3=A.xq("X6")
 B.xg=A.xq("ZX")
-B.h0=A.xq("a")
-B.Ry=A.xq("HS")
+B.Ry=A.xq("yc")
 B.zo=A.xq("Pz")
 B.xU=A.xq("zt")
 B.iY=A.xq("n6")})();(function staticFields(){$.zm=null
-$.Qu=A.j([],t.f)
+$.p=A.J([],A.q7("jd<Mh>"))
 $.xu=null
 $.i0=null
 $.Hb=null
@@ -2681,15 +3066,33 @@ $.x7=null
 $.nw=null
 $.vv=null
 $.Bv=null
-$.Bi=A.j([],A.q7("p<zM<a>?>"))
-$.j1=0})();(function lazyInitializers(){var s=hunkHelpers.lazyFinal
-s($,"fa","w",()=>A.Yg("_$dart_dartClosure"))
-s($,"hJ","u",()=>A.j([new J.B()],A.q7("p<rY>")))
+$.S6=null
+$.k8=null
+$.mg=null
+$.UD=!1
+$.X3=B.NU})();(function lazyInitializers(){var s=hunkHelpers.lazyFinal
+s($,"fa","w",()=>A.e("_$dart_dartClosure"))
+s($,"hJ","Ve",()=>A.J([new J.BC()],A.q7("jd<rY>")))
+s($,"lm","Sn",()=>A.cM(A.S7({
+toString:function(){return"$receiver$"}})))
+s($,"NJ","lq",()=>A.cM(A.S7({$method$:null,
+toString:function(){return"$receiver$"}})))
+s($,"Re","N9",()=>A.cM(A.S7(null)))
+s($,"fN","iI",()=>A.cM(function(){var $argumentsExpr$="$arguments$"
+try{null.$method$($argumentsExpr$)}catch(r){return r.message}}()))
+s($,"qi","UN",()=>A.cM(A.S7(void 0)))
+s($,"rZ","Zh",()=>A.cM(function(){var $argumentsExpr$="$arguments$"
+try{(void 0).$method$($argumentsExpr$)}catch(r){return r.message}}()))
+s($,"BX","rN",()=>A.cM(A.Mj(null)))
+s($,"tt","c3",()=>A.cM(function(){try{null.$method$}catch(r){return r.message}}()))
+s($,"dt","HK",()=>A.cM(A.Mj(void 0)))
+s($,"A7","r1",()=>A.cM(function(){try{(void 0).$method$}catch(r){return r.message}}()))
+s($,"Wc","ut",()=>A.xg())
 s($,"mf","z4",()=>A.nu("^[\\-\\.0-9A-Z_a-z~]*$"))
 s($,"Cc","Ob",()=>typeof URLSearchParams=="function")
-s($,"X0","t8",()=>A.CU(B.h0))
+s($,"cX","Un",()=>"*")
 s($,"Zj","Ww",()=>{var r=new A.lM()
-r.U()
+r.Ny()
 return r})})();(function nativeSupport(){!function(){var s=function(a){var m={}
 m[a]=1
 return Object.keys(hunkHelpers.convertToFastObject(m))[0]}
@@ -2701,23 +3104,24 @@ for(var o=0;;o++){var n=s(p+"_"+o+"_")
 if(!(n in q)){q[n]=1
 v.isolateTag=n
 break}}v.dispatchPropertyName=v.getIsolateTag("dispatch_record")}()
-hunkHelpers.setOrUpdateInterceptorsByTag({ArrayBuffer:A.WZ,ArrayBufferView:A.eH,DataView:A.df,Float32Array:A.zU,Float64Array:A.K8,Int16Array:A.xj,Int32Array:A.dE,Int8Array:A.Zc,Uint16Array:A.wf,Uint32Array:A.Pq,Uint8ClampedArray:A.eE,CanvasPixelArray:A.eE,Uint8Array:A.V6})
-hunkHelpers.setOrUpdateLeafTags({ArrayBuffer:true,ArrayBufferView:false,DataView:true,Float32Array:true,Float64Array:true,Int16Array:true,Int32Array:true,Int8Array:true,Uint16Array:true,Uint32Array:true,Uint8ClampedArray:true,CanvasPixelArray:true,Uint8Array:false})
+hunkHelpers.setOrUpdateInterceptorsByTag({ArrayBuffer:A.WZ,SharedArrayBuffer:A.WZ,ArrayBufferView:A.eH,DataView:A.df,Float32Array:A.zU,Float64Array:A.fS,Int16Array:A.xj,Int32Array:A.dE,Int8Array:A.Zc,Uint16Array:A.wf,Uint32Array:A.Pq,Uint8ClampedArray:A.eE,CanvasPixelArray:A.eE,Uint8Array:A.V6})
+hunkHelpers.setOrUpdateLeafTags({ArrayBuffer:true,SharedArrayBuffer:true,ArrayBufferView:false,DataView:true,Float32Array:true,Float64Array:true,Int16Array:true,Int32Array:true,Int8Array:true,Uint16Array:true,Uint32Array:true,Uint8ClampedArray:true,CanvasPixelArray:true,Uint8Array:false})
 A.b0.$nativeSuperclassTag="ArrayBufferView"
 A.RG.$nativeSuperclassTag="ArrayBufferView"
 A.vX.$nativeSuperclassTag="ArrayBufferView"
 A.Dg.$nativeSuperclassTag="ArrayBufferView"
 A.WB.$nativeSuperclassTag="ArrayBufferView"
-A.VS.$nativeSuperclassTag="ArrayBufferView"
+A.ZG.$nativeSuperclassTag="ArrayBufferView"
 A.DV.$nativeSuperclassTag="ArrayBufferView"})()
+Function.prototype.$2=function(a,b){return this(a,b)}
 Function.prototype.$0=function(){return this()}
 Function.prototype.$1=function(a){return this(a)}
-Function.prototype.$2=function(a,b){return this(a,b)}
-Function.prototype.$1$1=function(a){return this(a)}
+Function.prototype.$3=function(a,b,c){return this(a,b,c)}
+Function.prototype.$4=function(a,b,c,d){return this(a,b,c,d)}
 convertAllToFastObject(w)
 convertToFastObject($);(function(a){if(typeof document==="undefined"){a(null)
 return}if(typeof document.currentScript!="undefined"){a(document.currentScript)
 return}var s=document.scripts
 function onLoad(b){for(var q=0;q<s.length;++q){s[q].removeEventListener("load",onLoad,false)}a(b.target)}for(var r=0;r<s.length;++r){s[r].addEventListener("load",onLoad,false)}})(function(a){v.currentScript=a
-var s=A.E2
+var s=A.E
 if(typeof dartMainRunner==="function"){dartMainRunner(s,[])}else{s([])}})})()

--- a/pkgs/inject_dartpad/pubspec.yaml
+++ b/pkgs/inject_dartpad/pubspec.yaml
@@ -6,13 +6,13 @@ environment:
 
 dependencies:
   html_unescape: ^2.0.0
-  web: ^1.1.0
+  web: ^1.1.1
 
 dev_dependencies:
   analysis_defaults:
     path: ../analysis_defaults
-  build_runner: ^2.4.15
-  build_web_compilers: ^4.1.5
-  path: ^1.9.0
-  test: ^1.25.9
-  webdev: any
+  build_runner: ^2.7.0
+  build_web_compilers: ^4.2.2
+  path: ^1.9.1
+  test: ^1.26.3
+  webdev: ^3.7.2

--- a/pkgs/inject_dartpad/pubspec.yaml
+++ b/pkgs/inject_dartpad/pubspec.yaml
@@ -11,8 +11,8 @@ dependencies:
 dev_dependencies:
   analysis_defaults:
     path: ../analysis_defaults
-  build_runner: ^2.8.0
-  build_web_compilers: ^4.2.3
+  build_runner: ^2.9.0
+  build_web_compilers: ^4.3.0
   path: ^1.9.1
   test: ^1.26.3
   webdev: ^3.7.2

--- a/pkgs/inject_dartpad/pubspec.yaml
+++ b/pkgs/inject_dartpad/pubspec.yaml
@@ -11,8 +11,8 @@ dependencies:
 dev_dependencies:
   analysis_defaults:
     path: ../analysis_defaults
-  build_runner: ^2.7.0
-  build_web_compilers: ^4.2.2
+  build_runner: ^2.8.0
+  build_web_compilers: ^4.2.3
   path: ^1.9.1
   test: ^1.26.3
   webdev: ^3.7.2

--- a/pkgs/inject_dartpad/tool/compile.dart
+++ b/pkgs/inject_dartpad/tool/compile.dart
@@ -7,11 +7,7 @@ import 'dart:io';
 import 'package:path/path.dart' as path;
 
 void main() {
-  Process.runSync(Platform.resolvedExecutable, const [
-    'run',
-    'webdev',
-    'build',
-  ]);
+  Process.runSync(Platform.executable, const ['run', 'webdev', 'build']);
 
   final builtFile = File(path.join('build', 'inject_dartpad.dart.js'));
   builtFile.copySync(path.join('lib', 'inject_dartpad.js'));

--- a/pkgs/inject_dartpad/tool/compile.dart
+++ b/pkgs/inject_dartpad/tool/compile.dart
@@ -10,5 +10,5 @@ void main() {
   Process.runSync(Platform.executable, const ['run', 'webdev', 'build']);
 
   final builtFile = File(path.join('build', 'inject_dartpad.dart.js'));
-  builtFile.copySync(path.join('lib', 'inject_dartpad.js'));
+  builtFile.copySync(path.join('lib', 'inject_dartpad.dart.js'));
 }

--- a/pkgs/inject_dartpad/web/inject_dartpad.dart
+++ b/pkgs/inject_dartpad/web/inject_dartpad.dart
@@ -2,105 +2,80 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:js_interop';
-
 import 'package:html_unescape/html_unescape_small.dart';
+import 'package:inject_dartpad/inject_dartpad.dart';
 import 'package:web/web.dart' as web;
 
-void main() {
+void main() async {
   // Select all `code` elements with the `dartpad` attribute that are
   // the only child of a `pre` element.
   final codeElements = web.document.querySelectorAll(
     'pre > code[data-dartpad]:only-child',
   );
 
-  final embeds = <String, String>{};
-  web.window.addEventListener(
-    'message',
-    (web.MessageEvent event) {
-      if (event.data case _EmbedReadyMessage(
-        :final type?,
-        :final sender?,
-      ) when type == 'ready') {
-        if (embeds[sender] case final code?) {
-          final iframe =
-              web.document.getElementById(sender) as web.HTMLIFrameElement;
-          iframe.contentWindowCrossOrigin?.postMessage(
-            {'sourceCode': code, 'type': 'sourceCode'}.jsify(),
-            '*'.toJS,
-          );
-          embeds.remove(sender);
-        }
-      }
-    }.toJS,
-  );
-
-  for (var index = 0; index < codeElements.length; index += 1) {
-    final codeElement = codeElements.item(index) as web.HTMLElement;
-    if (_injectEmbed(codeElement) case final injectedEmbed?) {
-      final (:id, :code) = injectedEmbed;
-      embeds[id] = code;
-    }
-  }
+  await [
+    for (var index = 0; index < codeElements.length; index += 1)
+      _injectEmbed(codeElements.item(index) as web.HTMLElement, index),
+  ].wait;
 }
 
-final _htmlUnescape = HtmlUnescape();
-
-int _currentEmbed = 0;
-
-({String id, String code})? _injectEmbed(web.HTMLElement codeElement) {
+Future<EmbeddedDartPad?> _injectEmbed(
+  web.HTMLElement codeElement,
+  int embedNumber,
+) async {
   final parent = codeElement.parentElement;
   if (parent == null) return null;
-
-  final urlAuthority = switch (codeElement.getAttribute('data-url')) {
-    final specifiedHost? when specifiedHost.isNotEmpty => specifiedHost,
-    _ => 'dartpad.dev',
-  };
-
-  final iframeUrl = Uri.https(urlAuthority, '', {
-    if (codeElement.getAttribute('data-embed') != 'false') 'embed': 'true',
-    if (codeElement.getAttribute('data-theme') == 'light') 'theme': 'light',
-    if (codeElement.getAttribute('data-run') == 'true') 'run': 'true',
-  }).toString();
-
-  final host = web.HTMLDivElement();
-  final iframe = web.HTMLIFrameElement();
-
-  iframe.setAttribute('src', iframeUrl);
-  if (codeElement.getAttribute('title') case final title?
-      when title.isNotEmpty) {
-    iframe.setAttribute('title', title);
-  }
-
-  iframe.classList.add('embedded-dartpad');
-  final currentId = 'embedded-dartpad-${_currentEmbed++}';
-  iframe.id = currentId;
-  iframe.name = currentId;
-
-  if (codeElement.getAttribute('data-width') case final width?
-      when width.isNotEmpty) {
-    iframe.style.width = width;
-  }
-
-  if (codeElement.getAttribute('data-height') case final height?
-      when height.isNotEmpty) {
-    iframe.style.height = height;
-  }
 
   final content = _htmlUnescape.convert(
     codeElement.innerHTML.toString().trimRight(),
   );
+  if (content.isEmpty) return null;
 
-  host.appendChild(iframe);
-  parent.replaceWith(host);
+  final embeddedDartPad = EmbeddedDartPad.create(
+    iframeId: 'embedded-dartpad-$embedNumber',
+    host: switch (codeElement.getAttribute('data-url')) {
+      final specifiedHost? when specifiedHost.isNotEmpty => specifiedHost,
+      _ => null,
+    },
+    embedLayout: codeElement.getAttribute('data-embed') != 'false',
+    theme: codeElement.getAttribute('data-theme') == 'light'
+        ? DartPadTheme.light
+        : DartPadTheme.auto,
+  );
 
-  final contentWindow = iframe.contentWindow;
-  if (contentWindow == null) return null;
+  await embeddedDartPad.initialize(
+    addToDocument: (iframe) {
+      iframe.classList.add('embedded-dartpad');
+      if (codeElement.getAttribute('title') case final title?
+          when title.isNotEmpty) {
+        iframe.setAttribute('title', title);
+      }
 
-  return (id: currentId, code: content);
+      if (codeElement.getAttribute('data-width') case final width?
+          when width.isNotEmpty) {
+        iframe.style.width = width;
+      }
+
+      if (codeElement.getAttribute('data-height') case final height?
+          when height.isNotEmpty) {
+        iframe.style.height = height;
+      }
+
+      final host = web.HTMLDivElement();
+      host.appendChild(iframe);
+      parent.replaceWith(host);
+
+      final contentWindow = iframe.contentWindow;
+      if (contentWindow == null) {
+        host.replaceWith(parent);
+        print('Failed to inject embedded DartPad with content:\n');
+      }
+    },
+  );
+
+  embeddedDartPad.updateCode(content);
+
+  return embeddedDartPad;
 }
 
-extension type _EmbedReadyMessage._(JSObject _) {
-  external String? get type;
-  external String? get sender;
-}
+final _htmlUnescape = HtmlUnescape();

--- a/pkgs/inject_dartpad/web/inject_dartpad.dart
+++ b/pkgs/inject_dartpad/web/inject_dartpad.dart
@@ -52,7 +52,7 @@ Future<EmbeddedDartPad?> _injectEmbed(
   );
 
   await embeddedDartPad.initialize(
-    addToDocument: (iframe) {
+    onElementCreated: (iframe) {
       iframe.classList.add('embedded-dartpad');
 
       // Extract the configuration options specified on


### PR DESCRIPTION
Previously `web/inject_dartpad.dart` was just written as a script for dart.dev and docs.flutter.dev, but the logic wasn't really reusable in other contexts and didn't have much error handling. This PR rewrites and moves the core logic into a new library and class at `lib/inject_dartpad.dart` that other clients can take advantage of through using this package as a git dependency.

Besides being a public library, the new library also makes a few improvements over the original script.

- Each embed independently handles its initialization and code update, resulting in shorter delays.
- Lazily loads embeds outside the current viewport.
- Replaces usage of `jsify` with directly constructing the appropriate JS object.
- Adds handling and helpful error messages for when the embed isn't successfully added to the DOM.

The script in `web/inject_dartpad.dart` was then updated to use the new library, with a few additional improvements:

- Concurrently initializes multiple embeds rather than one at a time.
- Gracefully falls back to showing the code if DartPad fails to load in each iframe.
- Reuses an embed's index compared to others on the page for its iframe ID, simplifying the set up logic.

\cc @craiglabenz Since I can't assign you as a reviewer. I guess you don't have write access to this repo.