### PR TITLE
Build sites with Dart 3.12 beta

### DIFF
--- a/cloud_build/firebase-ghcli/Dockerfile
+++ b/cloud_build/firebase-ghcli/Dockerfile
@@ -1,4 +1,4 @@
-FROM dart:3.11.0
+FROM dart:3.12.0-327.4.beta
 
 # Install prerequisite dependencies.
 RUN apt-get update && apt-get install -y curl gpg


### PR DESCRIPTION
So we can start relying and building with Dart 3.12 features and fixes, including in `/examples` on `dart-lang/site-www`.