### PR TITLE
Clean up and reduce size of Cloud Build image

### DIFF
--- a/cloud_build/firebase-ghcli/Dockerfile
+++ b/cloud_build/firebase-ghcli/Dockerfile
@@ -1,12 +1,15 @@
-FROM dart:3.12.0-327.4.beta
+FROM dart:3.12.0-327.4.beta@sha256:5306c1008b585f0fbcf23aa0d7145b8f65cd7bd8c63dce4b8038684c11c79833
 
 # Install prerequisite dependencies.
-RUN apt-get update && apt-get install -y curl gpg
+RUN apt-get update && apt-get install -y --no-install-recommends curl gpg ca-certificates
 
-# Install the GitHub cli.
-RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg;
-RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null;
-RUN apt update && apt install -y gh;
+# Install the GitHub CLI.
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg
+RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends gh \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 # Install the latest version of firebase-tools globally.
 RUN curl -sL https://firebase.tools | bash

--- a/cloud_build/firebase-ghcli/cloudbuild.yaml
+++ b/cloud_build/firebase-ghcli/cloudbuild.yaml
@@ -1,6 +1,11 @@
 steps:
-- name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '-t', 'gcr.io/$PROJECT_ID/firebase-ghcli', 'cloud_build/firebase-ghcli']
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'build'
+      - '-t'
+      - 'gcr.io/$PROJECT_ID/firebase-ghcli'
+      - 'cloud_build/firebase-ghcli'
 images:
-- 'gcr.io/$PROJECT_ID/firebase-ghcli'
-tags: ['dash-firebase-ghcli']
+  - 'gcr.io/$PROJECT_ID/firebase-ghcli'
+tags:
+  - 'dash-firebase-ghcli'


### PR DESCRIPTION
- Adds a digest to the base image for reliability.
- Consistently use `apt-get`.
- Clean up after installing dependencies.
- Clean up YAML syntax.